### PR TITLE
Improve performance for `go to def`

### DIFF
--- a/src/languageFeatures/definitions.ts
+++ b/src/languageFeatures/definitions.ts
@@ -2,20 +2,75 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { ITextDocument } from '../types/textDocument';
-import { MdReferencesProvider } from './references';
-import * as lsp from 'vscode-languageserver-types';
 import { CancellationToken } from 'vscode-languageserver';
+import * as lsp from 'vscode-languageserver-types';
+import { LsConfiguration } from '../config';
+import { MdTableOfContentsProvider } from '../tableOfContents';
+import { rangeContains } from '../types/range';
+import { ITextDocument } from '../types/textDocument';
+import { IWorkspace, statLinkToMarkdownFile } from '../workspace';
+import { MdWorkspaceInfoCache } from '../workspaceCache';
+import { LinkDefinitionSet, MdLink } from './documentLinks';
 
 export class MdDefinitionProvider {
 
 	constructor(
-		private readonly referencesProvider: MdReferencesProvider,
+		private readonly configuration: LsConfiguration,
+		private readonly workspace: IWorkspace,
+		private readonly tocProvider: MdTableOfContentsProvider,
+		private readonly linkCache: MdWorkspaceInfoCache<readonly MdLink[]>,
 	) { }
 
 	async provideDefinition(document: ITextDocument, position: lsp.Position, token: CancellationToken): Promise<lsp.Definition | undefined> {
-		const allRefs = await this.referencesProvider.getReferencesAtPosition(document, position, token);
-		return allRefs.find(ref => ref.isDefinition)?.location;
+		const toc = await this.tocProvider.getForDocument(document);
+		if (token.isCancellationRequested) {
+			return [];
+		}
+
+		const header = toc.entries.find(entry => entry.line === position.line);
+		if (header) {
+			return header.headerLocation;
+		}
+
+		return this.getDefinitionOfLinkAtPosition(document, position, token);
+	}
+
+	private async getDefinitionOfLinkAtPosition(document: ITextDocument, position: lsp.Position, token: CancellationToken): Promise<lsp.Definition | undefined> {
+		const docLinks = (await this.linkCache.getForDocs([document]))[0];
+
+		for (const link of docLinks) {
+			if (link.kind === 'definition' && rangeContains(link.ref.range, position)) {
+				return this.getDefinitionOfRef(link.ref.text, docLinks);
+			}
+			if (rangeContains(link.source.hrefRange, position)) {
+				return this.getDefinitionOfLink(link, docLinks, token);
+			}
+		}
+
+		return undefined;
+	}
+
+	private async getDefinitionOfLink(sourceLink: MdLink, allLinksInFile: readonly MdLink[], token: CancellationToken): Promise<lsp.Definition | undefined> {
+		if (sourceLink.href.kind === 'reference') {
+			return this.getDefinitionOfRef(sourceLink.href.ref, allLinksInFile);
+		}
+
+		if (sourceLink.href.kind === 'external' || !sourceLink.href.fragment) {
+			return undefined;
+		}
+
+		const resolvedResource = await statLinkToMarkdownFile(this.configuration, this.workspace, sourceLink.href.path);
+		if (!resolvedResource || token.isCancellationRequested) {
+			return undefined;
+		}
+
+		const toc = await this.tocProvider.get(resolvedResource);
+		return toc.lookup(sourceLink.href.fragment)?.headerLocation;
+	}
+
+	private getDefinitionOfRef(ref: string, allLinksInFile: readonly MdLink[]) {
+		const allDefinitions = new LinkDefinitionSet(allLinksInFile);
+		const def = allDefinitions.lookup(ref);
+		return def ? { range: def.source.range, uri: def.source.resource.toString() } : undefined;
 	}
 }
-

--- a/src/languageFeatures/documentLinks.ts
+++ b/src/languageFeatures/documentLinks.ts
@@ -17,7 +17,7 @@ import { noopToken } from '../util/cancellation';
 import { Disposable } from '../util/dispose';
 import { r } from '../util/string';
 import { getWorkspaceFolder, IWorkspace } from '../workspace';
-import { MdDocumentInfoCache } from '../workspaceCache';
+import { MdDocumentInfoCache, MdWorkspaceInfoCache } from '../workspaceCache';
 
 
 export interface ExternalHref {
@@ -679,9 +679,17 @@ export class MdLinkProvider extends Disposable {
 	}
 }
 
-export interface VsCodeIRange {
+interface VsCodeIRange {
 	readonly startLineNumber: number;
 	readonly startColumn: number;
 	readonly endLineNumber: number;
 	readonly endColumn: number;
+}
+
+export function createWorkspaceLinkCache(
+	parser: IMdParser,
+	workspace: IWorkspace,
+) {
+	const linkComputer = new MdLinkComputer(parser, workspace);
+	return new MdWorkspaceInfoCache(workspace, doc => linkComputer.getAllLinks(doc, noopToken));
 }

--- a/src/test/fileReferences.test.ts
+++ b/src/test/fileReferences.test.ts
@@ -6,6 +6,7 @@
 import * as assert from 'assert';
 import { URI } from 'vscode-uri';
 import { getLsConfiguration } from '../config';
+import { createWorkspaceLinkCache } from '../languageFeatures/documentLinks';
 import { MdReference, MdReferencesProvider } from '../languageFeatures/references';
 import { MdTableOfContentsProvider } from '../tableOfContents';
 import { noopToken } from '../util/cancellation';
@@ -21,7 +22,8 @@ import { joinLines, withStore, workspacePath } from './util';
 function getFileReferences(store: DisposableStore, resource: URI, workspace: IWorkspace) {
 	const engine = createNewMarkdownEngine();
 	const tocProvider = store.add(new MdTableOfContentsProvider(engine, workspace, nulLogger));
-	const computer = store.add(new MdReferencesProvider(getLsConfiguration({}), engine, workspace, tocProvider, nulLogger));
+	const linkCache = store.add(createWorkspaceLinkCache(engine, workspace));
+	const computer = store.add(new MdReferencesProvider(getLsConfiguration({}), engine, workspace, tocProvider, linkCache, nulLogger));
 	return computer.getReferencesToFileInWorkspace(resource, noopToken);
 }
 

--- a/src/test/references.test.ts
+++ b/src/test/references.test.ts
@@ -7,6 +7,7 @@ import * as assert from 'assert';
 import * as lsp from 'vscode-languageserver-types';
 import { URI } from 'vscode-uri';
 import { getLsConfiguration } from '../config';
+import { createWorkspaceLinkCache } from '../languageFeatures/documentLinks';
 import { MdReferencesProvider } from '../languageFeatures/references';
 import { MdTableOfContentsProvider } from '../tableOfContents';
 import { comparePosition } from '../types/position';
@@ -23,7 +24,8 @@ import { joinLines, withStore, workspacePath, workspaceRoot } from './util';
 async function getReferences(store: DisposableStore, doc: InMemoryDocument, pos: lsp.Position, workspace: IWorkspace) {
 	const engine = createNewMarkdownEngine();
 	const tocProvider = store.add(new MdTableOfContentsProvider(engine, workspace, nulLogger));
-	const provider = store.add(new MdReferencesProvider(getLsConfiguration({}), engine, workspace, tocProvider, nulLogger));
+	const linkCache = store.add(createWorkspaceLinkCache(engine, workspace));
+	const provider = store.add(new MdReferencesProvider(getLsConfiguration({}), engine, workspace, tocProvider, linkCache, nulLogger));
 	const refs = await provider.provideReferences(doc, pos, { includeDeclaration: true }, noopToken);
 	return refs.sort((a, b) => {
 		const pathCompare = a.uri.toString().localeCompare(b.uri.toString());

--- a/src/test/rename.test.ts
+++ b/src/test/rename.test.ts
@@ -7,6 +7,7 @@ import * as assert from 'assert';
 import * as lsp from 'vscode-languageserver-types';
 import { URI } from 'vscode-uri';
 import { getLsConfiguration } from '../config';
+import { createWorkspaceLinkCache } from '../languageFeatures/documentLinks';
 import { MdReferencesProvider } from '../languageFeatures/references';
 import { MdRenameProvider, MdWorkspaceEdit } from '../languageFeatures/rename';
 import { githubSlugifier } from '../slugify';
@@ -29,7 +30,8 @@ function prepareRename(store: DisposableStore, doc: InMemoryDocument, pos: lsp.P
 	const config = getLsConfiguration({});
 	const engine = createNewMarkdownEngine();
 	const tocProvider = store.add(new MdTableOfContentsProvider(engine, workspace, nulLogger));
-	const referenceComputer = store.add(new MdReferencesProvider(config, engine, workspace, tocProvider, nulLogger));
+	const linkCache = store.add(createWorkspaceLinkCache(engine, workspace));
+	const referenceComputer = store.add(new MdReferencesProvider(config, engine, workspace, tocProvider, linkCache, nulLogger));
 	const renameProvider = store.add(new MdRenameProvider(config, workspace, referenceComputer, githubSlugifier));
 	return renameProvider.prepareRename(doc, pos, noopToken);
 }
@@ -41,7 +43,8 @@ function getRenameEdits(store: DisposableStore, doc: InMemoryDocument, pos: lsp.
 	const config = getLsConfiguration({});
 	const engine = createNewMarkdownEngine();
 	const tocProvider = store.add(new MdTableOfContentsProvider(engine, workspace, nulLogger));
-	const referencesProvider = store.add(new MdReferencesProvider(config, engine, workspace, tocProvider, nulLogger));
+	const linkCache = store.add(createWorkspaceLinkCache(engine, workspace));
+	const referencesProvider = store.add(new MdReferencesProvider(config, engine, workspace, tocProvider, linkCache, nulLogger));
 	const renameProvider = store.add(new MdRenameProvider(config, workspace, referencesProvider, githubSlugifier));
 	return renameProvider.provideRenameEditsImpl(doc, pos, newName, noopToken);
 }


### PR DESCRIPTION
This rewrites `go to def` to not use `find all references`. Doing so is slow on large workspaces as it needs to scan through every file in the workspace. We don't need to do that when looking up a definition

From https://github.com/microsoft/vscode/issues/152494