### PR TITLE
Make rename file preserve the file extension

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,8 @@ export interface LsConfiguration {
 	 * List of file extensions should be considered markdown.
 	 *
 	 * These should not include the leading `.`.
+	 *
+	 * The first entry is treated as the default file extension.
 	 */
 	readonly markdownFileExtensions: readonly string[];
 
@@ -22,8 +24,10 @@ export interface LsConfiguration {
 	readonly knownLinkedToFileExtensions: readonly string[];
 }
 
+export const defaultMarkdownFileExtension = 'md';
+
 const defaultConfig: LsConfiguration = {
-	markdownFileExtensions: ['md'],
+	markdownFileExtensions: [defaultMarkdownFileExtension],
 	knownLinkedToFileExtensions: [
 		'jpg',
 		'jpeg',

--- a/src/languageFeatures/rename.ts
+++ b/src/languageFeatures/rename.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import { CancellationToken } from 'vscode-languageserver';
 import * as lsp from 'vscode-languageserver-types';
 import { URI, Utils } from 'vscode-uri';
-import { LsConfiguration } from '../config';
+import { defaultMarkdownFileExtension, LsConfiguration } from '../config';
 import { ISlugifier } from '../slugify';
 import { arePositionsEqual, translatePosition } from '../types/position';
 import { modifyRange, rangeContains } from '../types/range';
@@ -159,11 +159,11 @@ export class MdRenameProvider extends Disposable {
 
 		let resolvedNewFilePath = rawNewFilePath.path;
 		if (!Utils.extname(resolvedNewFilePath)) {
-			// If the newly entered path doesn't have a file extension but the original file did
+			// If the newly entered path doesn't have a file extension but the original link did
 			// tack on a .md file extension
 			if (Utils.extname(targetUri)) {
 				resolvedNewFilePath = resolvedNewFilePath.with({
-					path: resolvedNewFilePath.path + '.md'
+					path: resolvedNewFilePath.path + '.' + (this.configuration.markdownFileExtensions[0] ?? defaultMarkdownFileExtension)
 				});
 			}
 		}


### PR DESCRIPTION
Updates rename file to try preserving the file extension

Also:

- Adds a test for rename file where file has spaces in the name
- Make `rename` use the language configuration to get the default markdown file extension instead of hardcoding `.md`