### PR TITLE
Adding more tooling for working with link definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Currently supported language features:
 
 	Supports renaming of headers and links.
 
+- Organize link definitions.
+
+	Groups and sorts link definitions in a file, optionally also removing unused definitions.
+
 - Diagnostics (experimental)
 
 	Supports generating diagnostics for invalid links to:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Currently supported language features:
 
 -  Code actions
 
-	Code action to extract all occurances
+	- Extract all occurrences of a link in a file to a link definition at the bottom of the file.
 
 - Diagnostics (experimental)
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Currently supported language features:
 
 	Groups and sorts link definitions in a file, optionally also removing unused definitions.
 
+-  Code actions
+
+	Code action to extract all occurances
+
 - Diagnostics (experimental)
 
 	Supports generating diagnostics for invalid links to:
@@ -127,7 +131,7 @@ const myDocument = TextDocument.create(
 	].join('\n')
 );
 
-const symbols = await languageService.getDocumentSymbols(myDocument, cts.token);
+const symbols = await languageService.getDocumentSymbols(myDocument, { includeLinkDefinitions: true }, cts.token);
 ```
 
 See [example.cjs](./example.cjs) for complete, minimal example of using the language service. You can run in using `node example.cjs`.

--- a/example.cjs
+++ b/example.cjs
@@ -105,7 +105,7 @@ async function main() {
 	// Request document symbols from the language service
 	const cts = new CancellationTokenSource();
 	try {
-		const symbols = await languageService.getDocumentSymbols(myDocument, cts.token);
+		const symbols = await languageService.getDocumentSymbols(myDocument, { includeLinkDefinitions: true }, cts.token);
 		console.log(JSON.stringify(symbols, null, 2))
 	} finally {
 		cts.dispose();

--- a/src/languageFeatures/codeActions/extractLinkDef.ts
+++ b/src/languageFeatures/codeActions/extractLinkDef.ts
@@ -1,0 +1,140 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from 'vscode-languageserver';
+import * as lsp from 'vscode-languageserver-types';
+import * as nls from 'vscode-nls';
+import { URI } from 'vscode-uri';
+import { translatePosition } from '../../types/position';
+import { makeRange, rangeIntersects } from '../../types/range';
+import { getLine, ITextDocument } from '../../types/textDocument';
+import { WorkspaceEditBuilder } from '../../util/editBuilder';
+import { ExternalHref, HrefKind, InternalHref, LinkDefinitionSet, MdDocumentLinksInfo, MdInlineLink, MdLink, MdLinkDefinition, MdLinkKind, MdLinkProvider } from '../documentLinks';
+import { getExistingDefinitionBlock } from '../organizeLinkDefs';
+
+const localize = nls.loadMessageBundle();
+
+export class MdExtractLinkDefinitionCodeActionProvider {
+
+	public static readonly genericTitle = localize('genericTitle', 'Extract to link definition');
+
+	private static kind = lsp.CodeActionKind.RefactorExtract + '.linkDefinition';
+
+	public static readonly notOnLinkAction: lsp.CodeAction = {
+		title: MdExtractLinkDefinitionCodeActionProvider.genericTitle,
+		kind: MdExtractLinkDefinitionCodeActionProvider.kind,
+		disabled: {
+			reason: localize('disabled.notOnLink', 'Not on link'),
+		}
+	};
+
+	public static readonly alreadyRefLinkAction: lsp.CodeAction = {
+		title: MdExtractLinkDefinitionCodeActionProvider.genericTitle,
+		kind: MdExtractLinkDefinitionCodeActionProvider.kind,
+		disabled: {
+			reason: localize('disabled.alreadyRefLink', 'Link is already a reference'),
+		}
+	};
+
+	constructor(
+		private readonly _linkProvider: MdLinkProvider
+	) { }
+
+	async getActions(doc: ITextDocument, range: lsp.Range, context: lsp.CodeActionContext, token: CancellationToken): Promise<lsp.CodeAction[]> {
+		if (!this.isEnabled(context)) {
+			return [];
+		}
+
+		const linkInfo = await this._linkProvider.getLinks(doc);
+		if (token.isCancellationRequested) {
+			return [];
+		}
+
+		const linksInRange = linkInfo.links.filter(link => link.kind !== MdLinkKind.Definition && rangeIntersects(range, link.source.range)) as MdInlineLink[];
+		if (!linksInRange.length) {
+			return [MdExtractLinkDefinitionCodeActionProvider.notOnLinkAction];
+		}
+
+		// Even though multiple links may be in the selection, we only generate an action for the first link we find.
+		// Creating actions for every link is overwhelming when users select all in a file
+		const targetLink = linksInRange.find(link => link.href.kind === HrefKind.External || link.href.kind === HrefKind.Internal);
+		if (!targetLink) {
+			return [MdExtractLinkDefinitionCodeActionProvider.alreadyRefLinkAction];
+		}
+
+		return [this.getExtractLinkAction(doc, linkInfo, targetLink as MdInlineLink<InternalHref | ExternalHref>)];
+	}
+
+	private isEnabled(context: lsp.CodeActionContext): boolean {
+		if (typeof context.only === 'undefined') {
+			return true;
+		}
+
+		return context.only.some(kind => codeActionKindContains(lsp.CodeActionKind.Refactor, kind));
+	}
+
+	private getExtractLinkAction(doc: ITextDocument, linkInfo: MdDocumentLinksInfo, targetLink: MdInlineLink<InternalHref | ExternalHref>): lsp.CodeAction {
+		const builder = new WorkspaceEditBuilder();
+		const resource = URI.parse(doc.uri);
+		const placeholder = this.getPlaceholder(linkInfo.definitions);
+
+		// Rewrite all inline occurrences of the link
+		for (const link of linkInfo.links) {
+			if (link.kind === MdLinkKind.Link && this.matchesHref(targetLink.href, link)) {
+				builder.replace(resource, link.source.targetRange, `[${placeholder}]`);
+			}
+		}
+
+		// And append new definition to link definition block
+		const definitionText = this.getLinkTargetText(doc, targetLink).trim();
+		const definitions = linkInfo.links.filter(link => link.kind === MdLinkKind.Definition) as MdLinkDefinition[];
+		const defBlock = getExistingDefinitionBlock(doc, definitions);
+		if (!defBlock) {
+			builder.insert(resource, { line: doc.lineCount, character: 0 }, `\n\n[${placeholder}]: ${definitionText}`);
+		} else {
+			const line = getLine(doc, defBlock.endLine);
+			builder.insert(resource, { line: defBlock.endLine, character: line.length }, `\n[${placeholder}]: ${definitionText}`);
+		}
+
+		return {
+			title: MdExtractLinkDefinitionCodeActionProvider.genericTitle,
+			kind: MdExtractLinkDefinitionCodeActionProvider.kind,
+			edit: builder.getEdit(),
+		};
+	}
+
+	private getLinkTargetText(doc: ITextDocument, link: MdInlineLink) {
+		const afterHrefRange = makeRange(
+			translatePosition(link.source.targetRange.start, { characterDelta: 1 }),
+			translatePosition(link.source.targetRange.end, { characterDelta: -1 }));
+		return doc.getText(afterHrefRange);
+	}
+
+	private getPlaceholder(definitions: LinkDefinitionSet): string {
+		const base = 'def';
+		for (let i = 1; ; ++i) {
+			const name = i === 1 ? base : `${base}${i}`;
+			if (typeof definitions.lookup(name) === 'undefined') {
+				return name;
+			}
+		}
+	}
+
+	private matchesHref(href: InternalHref | ExternalHref, link: MdLink): boolean {
+		if (link.href.kind === HrefKind.External && href.kind === HrefKind.External) {
+			return link.href.uri.toString() === href.uri.toString();
+		}
+
+		if (link.href.kind === HrefKind.Internal && href.kind === HrefKind.Internal) {
+			return link.href.path.toString() === href.path.toString() && link.href.fragment === href.fragment;
+		}
+
+		return false;
+	}
+}
+
+function codeActionKindContains(kindA: string, kindB: string): unknown {
+	return kindA === kindB || kindB.startsWith(kindA + '.');
+}

--- a/src/languageFeatures/organizeLinkDefs.ts
+++ b/src/languageFeatures/organizeLinkDefs.ts
@@ -1,0 +1,143 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from 'vscode-languageserver';
+import * as lsp from 'vscode-languageserver-types';
+import { makeRange } from '../types/range';
+import { getLine, ITextDocument } from '../types/textDocument';
+import { isEmptyOrWhitespace } from '../util/string';
+import { HrefKind, MdLinkDefinition, MdLinkKind, MdLinkProvider } from './documentLinks';
+
+export class MdOrganizeLinkDefinitionProvider {
+
+	constructor(
+		private readonly _linkProvider: MdLinkProvider
+	) { }
+
+	async getOrganizeLinkDefinitionEdits(doc: ITextDocument, options: { readonly removeUnused?: boolean }, token: CancellationToken): Promise<lsp.TextEdit[]> {
+		const links = await this._linkProvider.getLinks(doc);
+		if (token.isCancellationRequested) {
+			return [];
+		}
+
+		const definitions = links.links.filter(link => link.kind === MdLinkKind.Definition) as MdLinkDefinition[];
+		if (!definitions.length) {
+			return [];
+		}
+
+
+		const existingDefBlockRange = this.getTargetDefinitionBlockRanges(doc, definitions);
+		const edits: lsp.TextEdit[] = [];
+
+		// First replace all inline definitions that are not the definition block
+		for (const group of this.getDefinitionBlockGroups(doc, definitions)) {
+			if (!existingDefBlockRange || group.startLine < existingDefBlockRange.startLine) {
+				// Don't replace trailing newline of last definition in group
+				edits.push({
+					newText: '',
+					range: makeRange(group.startLine, 0, group.endLine, getLine(doc, group.endLine).length),
+				});
+			}
+		}
+
+		// Then replace the actual block
+		const sortedDefs = [...definitions];
+		sortedDefs.sort((a, b) => a.ref.text.localeCompare(b.ref.text));
+
+		const newDefs = sortedDefs
+			.filter(def => {
+				if (!options.removeUnused) {
+					return true;
+				}
+				return links.links.some(link => {
+					return link.kind === MdLinkKind.Link && link.href.kind === HrefKind.Reference && link.href.ref === def.ref.text;
+				});
+			});
+
+		const defBlock = newDefs
+			.map((def => `[${def.ref.text}]: ${def.source.hrefText}`))
+			.join('\n');
+
+		if (existingDefBlockRange) {
+			// We still may need to insert a newline
+			const hasLeadingWhiteSpace = existingDefBlockRange.startLine <= 0
+				|| isEmptyOrWhitespace(getLine(doc, existingDefBlockRange.startLine - 1));
+
+			// See if we already have the expected definitions in order
+			if (!edits.length && newDefs.length === definitions.length && definitions.every((def, i) => def.ref === newDefs[i].ref)) {
+				return [];
+			}
+
+			edits.push({
+				newText: (hasLeadingWhiteSpace ? '' : '\n') + defBlock,
+				range: makeRange(existingDefBlockRange.startLine, 0, existingDefBlockRange.endLine, getLine(doc, existingDefBlockRange.endLine).length)
+			});
+		} else {
+			const line = this.getLastNonWhitespaceLine(doc, definitions);
+			edits.push({
+				newText: (line === doc.lineCount - 1 ? '\n\n' : '\n') + defBlock,
+				range: makeRange(line + 1, 0, doc.lineCount, 0),
+			});
+		}
+
+		return edits;
+	}
+
+	private *getDefinitionBlockGroups(doc: ITextDocument, definitions: readonly MdLinkDefinition[]): Iterable<{ readonly startLine: number, readonly endLine: number }> {
+		if (!definitions.length) {
+			return;
+		}
+
+		let i = 0;
+		const startDef = definitions[i];
+		let endDef = startDef;
+		for (; i < definitions.length - 1; ++i) {
+			const nextDef = definitions[i + 1];
+			if (nextDef.source.range.start.line === endDef.source.range.start.line + 1) {
+				endDef = nextDef;
+			} else {
+				break;
+			}
+		}
+
+		yield { startLine: startDef.source.range.start.line, endLine: endDef.source.range.start.line };
+		yield* this.getDefinitionBlockGroups(doc, definitions.slice(i + 1));
+	}
+
+	private getTargetDefinitionBlockRanges(doc: ITextDocument, orderedDefinitions: readonly MdLinkDefinition[]): { startLine: number, endLine: number } | undefined {
+		const lastDef = orderedDefinitions[orderedDefinitions.length - 1];
+
+		const textAfter = doc.getText(makeRange(lastDef.source.range.end.line + 1, 0, Infinity, 0));
+		if (isEmptyOrWhitespace(textAfter)) {
+			let prevDef = lastDef;
+			for (let i = orderedDefinitions.length - 1; i >= 0; --i) {
+				const def = orderedDefinitions[i];
+				if (def.source.range.start.line < prevDef.source.range.start.line - 1) {
+					break;
+				}
+				prevDef = def;
+			}
+			return {
+				startLine: prevDef.source.range.start.line,
+				endLine: lastDef.source.range.start.line
+			};
+		}
+
+		return undefined;
+	}
+
+	private getLastNonWhitespaceLine(doc: ITextDocument, orderedDefinitions: readonly MdLinkDefinition[]): number {
+		const lastDef = orderedDefinitions[orderedDefinitions.length - 1];
+		const textAfter = doc.getText(makeRange(lastDef.source.range.end.line + 1, 0, Infinity, 0));
+		const lines = textAfter.split(/\r\n|\n/g);
+		for (let i = lines.length - 1; i >= 0; --i) {
+			if (!isEmptyOrWhitespace(lines[i])) {
+				return lastDef.source.range.start.line + 1 + i;
+			}
+		}
+
+		return lastDef.source.range.start.line;
+	}
+}

--- a/src/test/diagnostic.test.ts
+++ b/src/test/diagnostic.test.ts
@@ -365,6 +365,25 @@ suite('Diagnostic Computer', () => {
 			makeRange(3, 14, 3, 22),
 		]);
 	}));
+
+	test('Should use filename without brackets for bracketed link', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('doc1.md'), joinLines(
+			`[link](<no such.md>)`,
+			``,
+			`[def]: <no such.md>`,
+		));
+		const workspace = store.add(new InMemoryWorkspace([doc]));
+
+		const diagnostics = await getComputedDiagnostics(store, doc, workspace);
+		assertDiagnosticsEqual(diagnostics, [
+			makeRange(0, 8, 0, 18),
+			makeRange(2, 8, 2, 18),
+		]);
+
+		const [diag1, diag2] = diagnostics;
+		assert.strictEqual(diag1.data.fsPath, workspacePath('no such.md').fsPath);
+		assert.strictEqual(diag2.data.fsPath, workspacePath('no such.md').fsPath);
+	}));
 });
 
 

--- a/src/test/extractLinkDef.test.ts
+++ b/src/test/extractLinkDef.test.ts
@@ -1,0 +1,276 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import * as assert from 'assert';
+import * as lsp from 'vscode-languageserver-types';
+import { MdLinkProvider } from '../languageFeatures/documentLinks';
+import { MdExtractLinkDefinitionCodeActionProvider } from '../languageFeatures/codeActions/extractLinkDef';
+import { MdTableOfContentsProvider } from '../tableOfContents';
+import { noopToken } from '../util/cancellation';
+import { DisposableStore } from '../util/dispose';
+import { createNewMarkdownEngine } from './engine';
+import { InMemoryDocument } from './inMemoryDocument';
+import { InMemoryWorkspace } from './inMemoryWorkspace';
+import { nulLogger } from './nulLogging';
+import { joinLines, withStore, workspacePath } from './util';
+import { makeRange } from '../types/range';
+
+async function getExtractActions(store: DisposableStore, doc: InMemoryDocument, pos: lsp.Position): Promise<lsp.CodeAction[]> {
+	const workspace = store.add(new InMemoryWorkspace([doc]));
+	const engine = createNewMarkdownEngine();
+	const tocProvider = store.add(new MdTableOfContentsProvider(engine, workspace, nulLogger));
+	const linkProvider = store.add(new MdLinkProvider(engine, workspace, tocProvider, nulLogger));
+	const provider = new MdExtractLinkDefinitionCodeActionProvider(linkProvider);
+	return provider.getActions(doc, makeRange(pos, pos), lsp.CodeActionContext.create([], undefined, undefined), noopToken);
+}
+
+function applyActionEdit(doc: InMemoryDocument, action: lsp.CodeAction): string {
+	const edits = (action.edit?.documentChanges?.filter(change => {
+		return lsp.TextDocumentEdit.is(change) && change.textDocument.uri === doc.uri;
+	}) ?? []) as lsp.TextDocumentEdit[];
+	return doc.applyEdits(edits.map(edit => edit.edits).flat());
+}
+
+suite('Extract link definition code action', () => {
+	test('Should return disabled code action when not on link', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(
+			`test`
+		));
+		const actions = await getExtractActions(store, doc, { line: 0, character: 3 });
+		assert.strictEqual(actions.length, 1);
+		assert.strictEqual(actions[0].disabled?.reason, MdExtractLinkDefinitionCodeActionProvider.notOnLinkAction.disabled!.reason!);
+	}));
+
+	test('Should return disabled code action when already on reference link', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(
+			`[text][ref]`
+		));
+		const actions = await getExtractActions(store, doc, { line: 0, character: 3 });
+		assert.strictEqual(actions.length, 1);
+		assert.strictEqual(actions[0].disabled?.reason, MdExtractLinkDefinitionCodeActionProvider.alreadyRefLinkAction.disabled!.reason!);
+	}));
+
+	test('Should return action for simple internal link', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(
+			`[text](./img.png)`
+		));
+		const actions = await getExtractActions(store, doc, { line: 0, character: 3 });
+		assert.strictEqual(actions.length, 1);
+
+		const newContent = applyActionEdit(doc, actions[0]);
+		assert.strictEqual(newContent, joinLines(
+			`[text][def]`,
+			``,
+			`[def]: ./img.png`,
+		));
+	}));
+
+	test('Should be triggerable on link text or title', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(
+			`a [text](./img.png) b`
+		));
+
+		const expectedNewContent = joinLines(
+			`a [text][def] b`,
+			``,
+			`[def]: ./img.png`
+		);
+
+		{
+			// Before link
+			const actions = await getExtractActions(store, doc, { line: 0, character: 1 });
+			assert.strictEqual(actions.length, 1);
+			assert.strictEqual(actions[0].disabled?.reason, MdExtractLinkDefinitionCodeActionProvider.notOnLinkAction.disabled?.reason);
+		}
+		{
+			// On opening `[`
+			const actions = await getExtractActions(store, doc, { line: 0, character: 2 });
+			assert.strictEqual(actions.length, 1);
+			assert.strictEqual(applyActionEdit(doc, actions[0]), expectedNewContent);
+		}
+		{
+			// On opening link text
+			const actions = await getExtractActions(store, doc, { line: 0, character: 5 });
+			assert.strictEqual(actions.length, 1);
+			assert.strictEqual(applyActionEdit(doc, actions[0]), expectedNewContent);
+		}
+		{
+			// On link target
+			const actions = await getExtractActions(store, doc, { line: 0, character: 14 });
+			assert.strictEqual(actions.length, 1);
+			assert.strictEqual(applyActionEdit(doc, actions[0]), expectedNewContent);
+		}
+		{
+			// On closing `)`
+			const actions = await getExtractActions(store, doc, { line: 0, character: 19 });
+			assert.strictEqual(actions.length, 1);
+			assert.strictEqual(applyActionEdit(doc, actions[0]), expectedNewContent);
+		}
+		{
+			// After link
+			const actions = await getExtractActions(store, doc, { line: 0, character: 20 });
+			assert.strictEqual(actions.length, 1);
+			assert.strictEqual(actions[0].disabled?.reason, MdExtractLinkDefinitionCodeActionProvider.notOnLinkAction.disabled?.reason);
+		}
+	}));
+
+	test('Should add to existing link block', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(
+			`[text](./img.png)`,
+			``,
+			`[abc]: http:://example.com`
+		));
+		const actions = await getExtractActions(store, doc, { line: 0, character: 3 });
+		assert.strictEqual(actions.length, 1);
+
+		const newContent = applyActionEdit(doc, actions[0]);
+		assert.strictEqual(newContent, joinLines(
+			`[text][def]`,
+			``,
+			`[abc]: http:://example.com`,
+			`[def]: ./img.png`
+		));
+	}));
+
+	test('Should use new placeholder if existing is already taken', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(
+			`[text](http://example.com?3)`,
+			``,
+			`[def]: http:://example.com?1`,
+			`[def2]: http:://example.com?2`,
+			`[def4]: http:://example.com?4`,
+		));
+		const actions = await getExtractActions(store, doc, { line: 0, character: 3 });
+		assert.strictEqual(actions.length, 1);
+
+		const newContent = applyActionEdit(doc, actions[0]);
+		assert.strictEqual(newContent, joinLines(
+			`[text][def3]`,
+			``,
+			`[def]: http:://example.com?1`,
+			`[def2]: http:://example.com?2`,
+			`[def4]: http:://example.com?4`,
+			`[def3]: http://example.com?3`
+		));
+	}));
+
+	test('Should preserve title', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(
+			`[text](http://example.com "some title")`,
+			``,
+			`[abc]: http:://example.com`
+		));
+		const actions = await getExtractActions(store, doc, { line: 0, character: 3 });
+		assert.strictEqual(actions.length, 1);
+
+		const newContent = applyActionEdit(doc, actions[0]);
+		assert.strictEqual(newContent, joinLines(
+			`[text][def]`,
+			``,
+			`[abc]: http:://example.com`,
+			`[def]: http://example.com "some title"`,
+		));
+	}));
+
+	test('Should work for link with leading and trailing whitespace', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(
+			`[text](    http://example.com "some title"   )`,
+			``,
+			`[abc]: http:://example.com`
+		));
+		const actions = await getExtractActions(store, doc, { line: 0, character: 3 });
+		assert.strictEqual(actions.length, 1);
+
+		const newContent = applyActionEdit(doc, actions[0]);
+		assert.strictEqual(newContent, joinLines(
+			`[text][def]`,
+			``,
+			`[abc]: http:://example.com`,
+			`[def]: http://example.com "some title"`,
+		));
+	}));
+
+	test('Should work for bracketed link paths', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(
+			`[text](<path to img.png> "title text")`,
+			``,
+			`[abc]: http:://example.com`
+		));
+		const actions = await getExtractActions(store, doc, { line: 0, character: 3 });
+		assert.strictEqual(actions.length, 1);
+
+		const newContent = applyActionEdit(doc, actions[0]);
+		assert.strictEqual(newContent, joinLines(
+			`[text][def]`,
+			``,
+			`[abc]: http:://example.com`,
+			`[def]: <path to img.png> "title text"`,
+		));
+	}));
+
+	test('Should preserve trailing newlines', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(
+			`[text](/path/to/img.png)`,
+			``,
+			`[abc]: http:://example.com?abc`,
+			`[xyz]: http:://example.com?xyz`,
+			``,
+		));
+		const actions = await getExtractActions(store, doc, { line: 0, character: 3 });
+		assert.strictEqual(actions.length, 1);
+
+		const newContent = applyActionEdit(doc, actions[0]);
+		assert.strictEqual(newContent, joinLines(
+			`[text][def]`,
+			``,
+			`[abc]: http:://example.com?abc`,
+			`[xyz]: http:://example.com?xyz`,
+			`[def]: /path/to/img.png`,
+			``,
+		));
+	}));
+
+	test('Should replace all occurrences of link', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(
+			`a [text](/img.png) b`,
+			``,
+			`# c [text](/img.png)`,
+			``,
+			`[abc]: http:://example.com?abc`,
+		));
+		const actions = await getExtractActions(store, doc, { line: 0, character: 3 });
+		assert.strictEqual(actions.length, 1);
+
+		const newContent = applyActionEdit(doc, actions[0]);
+		assert.strictEqual(newContent, joinLines(
+			`a [text][def] b`,
+			``,
+			`# c [text][def]`,
+			``,
+			`[abc]: http:://example.com?abc`,
+			`[def]: /img.png`,
+		));
+	}));
+
+	test('Should not extract occurrences where fragments differ', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(
+			`a [text](http://example.com#a)`,
+			`b [text](http://example.com#b)`,
+			`a [text](http://example.com#a)`,
+		));
+		const actions = await getExtractActions(store, doc, { line: 0, character: 3 });
+		assert.strictEqual(actions.length, 1);
+
+		const newContent = applyActionEdit(doc, actions[0]);
+		assert.strictEqual(newContent, joinLines(
+			`a [text][def]`,
+			`b [text](http://example.com#b)`,
+			`a [text][def]`,
+			``,
+			`[def]: http://example.com#a`,
+		));
+	}));
+});
+
+

--- a/src/test/inMemoryDocument.ts
+++ b/src/test/inMemoryDocument.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { Position, Range, TextEdit } from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-types';
 import { URI } from 'vscode-uri';
 import { ITextDocument } from '../types/textDocument';
 
@@ -28,11 +28,11 @@ export class InMemoryDocument implements ITextDocument {
 		return this._doc.lineCount;
 	}
 
-	positionAt(offset: number): Position {
+	positionAt(offset: number): lsp.Position {
 		return this._doc.positionAt(offset);
 	}
 
-	getText(range?: Range): string {
+	getText(range?: lsp.Range): string {
 		return this._doc.getText(range);
 	}
 
@@ -41,7 +41,7 @@ export class InMemoryDocument implements ITextDocument {
 		this._doc = TextDocument.create(this.uri.toString(), 'markdown', this.version, newContent);
 	}
 
-	applyEdits(textEdits: TextEdit[]): string {
+	applyEdits(textEdits: lsp.TextEdit[]): string {
 		return TextDocument.applyEdits(this._doc, textEdits);
 	}
 }

--- a/src/test/inMemoryDocument.ts
+++ b/src/test/inMemoryDocument.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { Position, Range } from 'vscode-languageserver-types';
+import { Position, Range, TextEdit } from 'vscode-languageserver-types';
 import { URI } from 'vscode-uri';
 import { ITextDocument } from '../types/textDocument';
 
@@ -39,5 +39,9 @@ export class InMemoryDocument implements ITextDocument {
 	updateContent(newContent: string) {
 		++this.version;
 		this._doc = TextDocument.create(this.uri.toString(), 'markdown', this.version, newContent);
+	}
+
+	applyEdits(textEdits: TextEdit[]): string {
+		return TextDocument.applyEdits(this._doc, textEdits);
 	}
 }

--- a/src/test/organizeLinkDef.test.ts
+++ b/src/test/organizeLinkDef.test.ts
@@ -1,0 +1,291 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import * as assert from 'assert';
+import * as lsp from 'vscode-languageserver-types';
+import { MdLinkProvider } from '../languageFeatures/documentLinks';
+import { MdOrganizeLinkDefinitionProvider } from '../languageFeatures/organizeLinkDefs';
+import { MdTableOfContentsProvider } from '../tableOfContents';
+import { noopToken } from '../util/cancellation';
+import { DisposableStore } from '../util/dispose';
+import { createNewMarkdownEngine } from './engine';
+import { InMemoryDocument } from './inMemoryDocument';
+import { InMemoryWorkspace } from './inMemoryWorkspace';
+import { nulLogger } from './nulLogging';
+import { joinLines, withStore, workspacePath } from './util';
+
+async function getOrganizeEdits(store: DisposableStore, doc: InMemoryDocument, removeUnused = false): Promise<lsp.TextEdit[]> {
+	const workspace = store.add(new InMemoryWorkspace([doc]));
+	const engine = createNewMarkdownEngine();
+	const tocProvider = store.add(new MdTableOfContentsProvider(engine, workspace, nulLogger));
+	const linkProvider = store.add(new MdLinkProvider(engine, workspace, tocProvider, nulLogger));
+	const organizer = new MdOrganizeLinkDefinitionProvider(linkProvider);
+	return organizer.getOrganizeLinkDefinitionEdits(doc, { removeUnused }, noopToken);
+}
+
+suite('Organize link definitions', () => {
+	test('Should return empty edit for file without links', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(`# h1`));
+		const edits = await getOrganizeEdits(store, doc);
+		assert.deepStrictEqual(edits, []);
+	}));
+
+	test('Should return empty if definitions are already sorted', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(
+			`[a]: http://example.com`,
+			`[b]: http://example.com`,
+		));
+		const edits = await getOrganizeEdits(store, doc);
+		assert.deepStrictEqual(edits, []);
+	}));
+
+	test('Should sort basic link definitions', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(
+			`[b]: http://example.com`,
+			`[a]: http://example.com`,
+		));
+		const edits = await getOrganizeEdits(store, doc);
+		const newContent = doc.applyEdits(edits);
+		assert.deepStrictEqual(newContent, joinLines(
+			`[a]: http://example.com`,
+			`[b]: http://example.com`,
+		));
+	}));
+
+	test('Should move link definition to bottom of file', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(
+			`x`,
+			`[a]: http://example.com`,
+			`y`,
+		));
+		const edits = await getOrganizeEdits(store, doc);
+		const newContent = doc.applyEdits(edits);
+		assert.deepStrictEqual(newContent, joinLines(
+			`x`,
+			``,
+			`y`,
+			``,
+			`[a]: http://example.com`,
+		));
+	}));
+
+	test('Should not add extra new line if one already exists', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(
+			`x`,
+			`[a]: http://example.com`,
+			`y`,
+			``,
+		));
+		const edits = await getOrganizeEdits(store, doc);
+		const newContent = doc.applyEdits(edits);
+		assert.deepStrictEqual(newContent, joinLines(
+			`x`,
+			``,
+			`y`,
+			``,
+			`[a]: http://example.com`,
+		));
+	}));
+
+	test('Should group link definitions to bottom of file', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(
+			`x`,
+			`[b]: http://example.com`,
+			`y`,
+			`[a]: http://example.com`,
+		));
+		const edits = await getOrganizeEdits(store, doc);
+		const newContent = doc.applyEdits(edits);
+		assert.deepStrictEqual(newContent, joinLines(
+			`x`,
+			``,
+			`y`,
+			``,
+			`[a]: http://example.com`,
+			`[b]: http://example.com`,
+		));
+	}));
+
+	test('Should sort existing definition block', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(
+			`* [SQL Server documentation]`,
+			`* [SQL Server on Linux documentation]`,
+			`* [SQL Server Blog]`,
+			``,
+			`[Transact-SQL]: https://docs.microsoft.com/sql/t-sql/language-reference`,
+			`[mssql]: https://aka.ms/mssql-marketplace`,
+			`[Download VS Code]: https://code.visualstudio.com/download`,
+			`[SQL Server 2017 Developer Edition]: https://www.microsoft.com/sql-server/sql-server-downloads`,
+			`[Build an app]: https://aka.ms/sqldev`,
+			`[SQL Server documentation]: https://docs.microsoft.com/sql/sql-server/sql-server-technical-documentation`,
+			`[SQL Server on Linux documentation]: https://docs.microsoft.com/sql/linux/`,
+			`[SQL Server Blog]: https://blogs.technet.microsoft.com/dataplatforminsider/`,
+			`[GitHub]: https://github.com/microsoft/vscode-mssql`,
+			`[GitHub Issue Tracker]: https://github.com/microsoft/vscode-mssql/issues`,
+		));
+		const edits = await getOrganizeEdits(store, doc);
+		const newContent = doc.applyEdits(edits);
+		assert.deepStrictEqual(newContent, joinLines(
+			`* [SQL Server documentation]`,
+			`* [SQL Server on Linux documentation]`,
+			`* [SQL Server Blog]`,
+			``,
+			`[Build an app]: https://aka.ms/sqldev`,
+			`[Download VS Code]: https://code.visualstudio.com/download`,
+			`[GitHub]: https://github.com/microsoft/vscode-mssql`,
+			`[GitHub Issue Tracker]: https://github.com/microsoft/vscode-mssql/issues`,
+			`[mssql]: https://aka.ms/mssql-marketplace`,
+			`[SQL Server 2017 Developer Edition]: https://www.microsoft.com/sql-server/sql-server-downloads`,
+			`[SQL Server Blog]: https://blogs.technet.microsoft.com/dataplatforminsider/`,
+			`[SQL Server documentation]: https://docs.microsoft.com/sql/sql-server/sql-server-technical-documentation`,
+			`[SQL Server on Linux documentation]: https://docs.microsoft.com/sql/linux/`,
+			`[Transact-SQL]: https://docs.microsoft.com/sql/t-sql/language-reference`,
+		));
+	}));
+
+	test('Should preserved trailing newline', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(
+			`x`,
+			`[b]: http://example.com`,
+			`y`,
+			``,
+			`[a]: http://example.com`,
+			``,
+		));
+		const edits = await getOrganizeEdits(store, doc);
+		const newContent = doc.applyEdits(edits);
+		assert.deepStrictEqual(newContent, joinLines(
+			`x`,
+			``,
+			`y`,
+			``,
+			`[a]: http://example.com`,
+			`[b]: http://example.com`,
+			``,
+		));
+	}));
+
+	test('Should leave behind single newline after moving definition', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(
+			`[z]: http://example.com?z`,
+			`a`,
+			`[x]: http://example.com?x`,
+			`[x2]: http://example.com?x2`,
+			`b`,
+			`[y]: http://example.com?y`,
+			`c`,
+			``,
+		));
+
+		const edits = await getOrganizeEdits(store, doc);
+		const newContent = doc.applyEdits(edits);
+		assert.deepStrictEqual(newContent, joinLines(
+			``,
+			`a`,
+			``,
+			`b`,
+			``,
+			`c`,
+			``,
+			`[x]: http://example.com?x`,
+			`[x2]: http://example.com?x2`,
+			`[y]: http://example.com?y`,
+			`[z]: http://example.com?z`,
+		));
+	}));
+
+	test('Should not move links within code blocks', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(
+			`[z]: http://example.com?z`,
+			`a`,
+			`~~~`,
+			`[x]: http://example.com?x`,
+			`~~~`,
+			``,
+			``,
+			`    [x2]: http://example.com?x2`,
+			``,
+			`b`,
+			`[y]: http://example.com?y`,
+			`c`,
+			``,
+		));
+
+		const edits = await getOrganizeEdits(store, doc);
+		const newContent = doc.applyEdits(edits);
+		assert.deepStrictEqual(newContent, joinLines(
+			``,
+			`a`,
+			`~~~`,
+			`[x]: http://example.com?x`,
+			`~~~`,
+			``,
+			``,
+			`    [x2]: http://example.com?x2`,
+			``,
+			`b`,
+			``,
+			`c`,
+			``,
+			`[y]: http://example.com?y`,
+			`[z]: http://example.com?z`,
+		));
+	}));
+
+	test('Should preserve order of duplicate link definitions', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(
+			`x`,
+			`[def]: http://example.com?1`,
+			`y`,
+			`[def]: http://example.com?2`,
+			`z`,
+		));
+		const edits = await getOrganizeEdits(store, doc);
+		const newContent = doc.applyEdits(edits);
+		assert.deepStrictEqual(newContent, joinLines(
+			`x`,
+			``,
+			`y`,
+			``,
+			`z`,
+			``,
+			`[def]: http://example.com?1`,
+			`[def]: http://example.com?2`,
+		));
+	}));
+
+	test('Should remove unused definitions when enabled', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(
+			`text [b] text`,
+			``,
+			`[a]: http://example.com`,
+			`[b]: http://example.com`,
+		));
+		const edits = await getOrganizeEdits(store, doc, /* removeUnused */ true);
+		const newContent = doc.applyEdits(edits);
+		assert.deepStrictEqual(newContent, joinLines(
+			`text [b] text`,
+			``,
+			`[b]: http://example.com`,
+		));
+	}));
+
+	test('Should sort and remove unused definitions when enabled', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('test.md'), joinLines(
+			`text [a] text [link][c]`,
+			``,
+			`[c]: http://example.com?c`,
+			`[b]: http://example.com?b`,
+			`[a]: http://example.com?a`,
+		));
+		const edits = await getOrganizeEdits(store, doc, /* removeUnused */ true);
+		const newContent = doc.applyEdits(edits);
+		assert.deepStrictEqual(newContent, joinLines(
+			`text [a] text [link][c]`,
+			``,
+			`[a]: http://example.com?a`,
+			`[c]: http://example.com?c`,
+		));
+	}));
+});

--- a/src/test/util.ts
+++ b/src/test/util.ts
@@ -10,8 +10,7 @@ import * as URI from 'vscode-uri';
 import { DisposableStore } from '../util/dispose';
 import { InMemoryDocument } from './inMemoryDocument';
 
-export const joinLines = (...args: string[]) =>
-	args.join(os.platform() === 'win32' ? '\r\n' : '\n');
+export const joinLines = (...args: string[]) => args.join('\n');
 
 export const workspaceRoot = URI.URI.file(os.platform() === 'win32' ? 'c:\\workspace' : '/workspace');
 

--- a/src/types/range.ts
+++ b/src/types/range.ts
@@ -43,3 +43,11 @@ export function rangeContains(range: Range, other: Position | Range): boolean {
 	}
 	return !isBefore(other, range.start) && !isBefore(range.end, other);
 }
+
+export function rangeIntersects(a: Range, b: Range): boolean {
+	if (rangeContains(a, b.start) || rangeContains(a, b.end)) {
+		return true;
+	}
+	// Check case where `a` is entirely contained in `b`
+	return rangeContains(b, a.start) || rangeContains(b, a.end);
+}

--- a/src/util/editBuilder.ts
+++ b/src/util/editBuilder.ts
@@ -11,7 +11,15 @@ export class WorkspaceEditBuilder {
 	private readonly changes: { [uri: lsp.DocumentUri]: lsp.TextEdit[]; } = {};
 	private readonly documentChanges: Array<lsp.CreateFile | lsp.RenameFile | lsp.DeleteFile> = [];
 
-	replace(resource: URI, range: lsp.Range, newText: string) {
+	replace(resource: URI, range: lsp.Range, newText: string): void {
+		this.addEdit(resource, lsp.TextEdit.replace(range, newText));
+	}
+
+	insert(resource: URI, position: lsp.Position, newText: string): void {
+		this.addEdit(resource, lsp.TextEdit.insert(position, newText));
+	}
+
+	private addEdit(resource: URI, edit: lsp.TextEdit): void {
 		const resourceKey = resource.toString();
 		let edits = this.changes![resourceKey];
 		if (!edits) {
@@ -19,7 +27,7 @@ export class WorkspaceEditBuilder {
 			this.changes![resourceKey] = edits;
 		}
 
-		edits.push(lsp.TextEdit.replace(range, newText));
+		edits.push(edit);
 	}
 
 	getEdit(): lsp.WorkspaceEdit {


### PR DESCRIPTION
Combination of a few different commits about link definitions that I added while on recent plane rides :)

- Add option to include link definitions in the document outline. Controlled by a new `includeLinkDefinitions` param

- Adds an organize link definition action. This groups all link definitions to the bottom of the file and sorts them Fixes #25

- Adds a code action for extracting a link to a definition Fixes #24 
