### PR TITLE
Always use active group for doc links

### DIFF
--- a/src/languageFeatures/documentLinks.ts
+++ b/src/languageFeatures/documentLinks.ts
@@ -682,7 +682,7 @@ export class MdLinkProvider extends Disposable {
 
 	private createOpenAtPosCommand(resource: URI, pos: lsp.Position): string {
 		// Workaround https://github.com/microsoft/vscode/issues/154993
-		return this.createCommandUri('_workbench.open', resource, [undefined, {
+		return this.createCommandUri('_workbench.open', resource, [-1 /* active group*/, {
 			selection: <VsCodeIRange>{
 				startLineNumber: pos.line + 1,
 				startColumn: pos.character + 1,


### PR DESCRIPTION
Something seems to have changed in the latest VS Code where `undefined` no longer defaults to active group