### PR TITLE
Fix workspace caching for rename

### DIFF
--- a/src/test/workspaceCache.test.ts
+++ b/src/test/workspaceCache.test.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { MdWorkspaceInfoCache } from '../workspaceCache';
+import { InMemoryDocument } from './inMemoryDocument';
+import { InMemoryWorkspace } from './inMemoryWorkspace';
+import { joinLines, withStore, workspacePath } from './util';
+
+
+suite('Workspace Cache', () => {
+
+	test('Entries should return basic value', withStore(async (_store) => {		
+		const uri = workspacePath('doc.md');
+		const contents = joinLines(
+			`# hello!`
+		);
+		const doc = new InMemoryDocument(uri, contents);
+		const cache = new MdWorkspaceInfoCache<string>(new InMemoryWorkspace([doc]), async doc => doc.getText());
+
+		const entires = await cache.entries();
+		assert.deepStrictEqual(entires.length, 1);
+		assert.deepStrictEqual(entires[0][0].toString(), uri.toString());
+		assert.deepStrictEqual(entires[0][1], contents);
+	}));
+
+	test('Entries should update when document changes', withStore(async (_store) => {
+		const uri = workspacePath('doc.md');
+		const originalContents = joinLines(
+			`# hello!`
+		);
+		const doc = new InMemoryDocument(uri, originalContents);
+		const workspace = new InMemoryWorkspace([doc]);
+		const cache = new MdWorkspaceInfoCache<string>(workspace, async doc => doc.getText());
+
+		{
+			const entires = await cache.entries();
+			assert.deepStrictEqual(entires.length, 1);
+			assert.deepStrictEqual(entires[0][0].toString(), uri.toString());
+			assert.deepStrictEqual(entires[0][1], originalContents);
+		}
+
+		const newContents = joinLines(
+			`new`
+		);
+		doc.updateContent(newContents);
+		workspace.updateDocument(doc);
+
+		{
+			const entires = await cache.entries();
+			assert.deepStrictEqual(entires.length, 1);
+			assert.deepStrictEqual(entires[0][0].toString(), uri.toString());
+			assert.deepStrictEqual(entires[0][1], newContents);
+		}
+	}));
+
+	test('GetForDocs should update when document changes', withStore(async (_store) => {
+		const uri = workspacePath('doc.md');
+		const originalContents = joinLines(
+			`# hello!`
+		);
+		const doc = new InMemoryDocument(uri, originalContents);
+		const workspace = new InMemoryWorkspace([doc]);
+		const cache = new MdWorkspaceInfoCache<string>(workspace, async doc => doc.getText());
+
+		{
+			const values = await cache.getForDocs([doc]);
+			assert.deepStrictEqual(values[0], originalContents);
+		}
+
+		const newContents = joinLines(
+			`new`
+		);
+		doc.updateContent(newContents);
+		workspace.updateDocument(doc);
+
+		{
+			const entires = await cache.entries();
+			assert.deepStrictEqual(entires.length, 1);
+			assert.deepStrictEqual(entires[0][0].toString(), uri.toString());
+			assert.deepStrictEqual(entires[0][1], newContents);
+		}
+	}));
+});

--- a/src/workspaceCache.ts
+++ b/src/workspaceCache.ts
@@ -132,6 +132,10 @@ export class MdWorkspaceInfoCache<T> extends Disposable {
 		private readonly getValue: (document: ITextDocument) => Promise<T>,
 	) {
 		super();
+
+		this._register(this.workspace.onDidChangeMarkdownDocument(this.onDidChangeDocument, this));
+		this._register(this.workspace.onDidCreateMarkdownDocument(this.onDidChangeDocument, this));
+		this._register(this.workspace.onDidDeleteMarkdownDocument(this.onDidDeleteDocument, this));
 	}
 
 	public async entries(): Promise<Array<[URI, T]>> {
@@ -157,17 +161,13 @@ export class MdWorkspaceInfoCache<T> extends Disposable {
 	private async ensureInit(): Promise<void> {
 		if (!this._init) {
 			this._init = this.populateCache();
-
-			this._register(this.workspace.onDidChangeMarkdownDocument(this.onDidChangeDocument, this));
-			this._register(this.workspace.onDidCreateMarkdownDocument(this.onDidChangeDocument, this));
-			this._register(this.workspace.onDidDeleteMarkdownDocument(this.onDidDeleteDocument, this));
 		}
 		await this._init;
 	}
 
 	private async populateCache(): Promise<void> {
-		const markdownDocumentUris = await this.workspace.getAllMarkdownDocuments();
-		for (const document of markdownDocumentUris) {
+		const markdownDocuments = await this.workspace.getAllMarkdownDocuments();
+		for (const document of markdownDocuments) {
 			if (!this._cache.has(URI.parse(document.uri))) {
 				this.update(document);
 			}


### PR DESCRIPTION
The workspace cache needs to have listeners hooked up early if any calls are made to `getForDocs`