### PR TITLE
Fix notebook document links

### DIFF
--- a/src/languageFeatures/fileRename.ts
+++ b/src/languageFeatures/fileRename.ts
@@ -96,9 +96,9 @@ export class MdFileRenameProvider extends Disposable {
 					});
 
 					const oldLink = resolveDocumentLink(oldDocUri, link.source.hrefText, this.workspace);
-					if (oldLink && !isParentDir(edit.oldUri, oldLink.path)) {
+					if (oldLink && !isParentDir(edit.oldUri, oldLink.resource)) {
 						const rootDir = Utils.dirname(docUri);
-						const newPath = path.relative(rootDir.path, oldLink.path.path);
+						const newPath = path.relative(rootDir.path, oldLink.resource.path);
 						builder.replace(docUri, getFilePathRange(link), encodeURI(newPath.replace(/\\/g, '/')));
 					}
 				}
@@ -142,7 +142,7 @@ export class MdFileRenameProvider extends Disposable {
 			const oldLink = resolveDocumentLink(edit.oldUri, link.source.hrefText, this.workspace);
 			if (oldLink) {
 				const rootDir = Utils.dirname(edit.newUri);
-				const newPath = path.relative(rootDir.toString(true), oldLink.path.toString(true));
+				const newPath = path.relative(rootDir.toString(true), oldLink.resource.toString(true));
 				builder.replace(edit.newUri, getFilePathRange(link), encodeURI(newPath.replace(/\\/g, '/')));
 			}
 		}

--- a/src/languageFeatures/rename.ts
+++ b/src/languageFeatures/rename.ts
@@ -144,7 +144,7 @@ export class MdRenameProvider extends Disposable {
 			return builder.getEdit();
 		}
 
-		let resolvedNewFilePath = rawNewFilePath.path;
+		let resolvedNewFilePath = rawNewFilePath.resource;
 		if (!Utils.extname(resolvedNewFilePath)) {
 			// If the newly entered path doesn't have a file extension but the original link did
 			// tack on a .md file extension
@@ -164,7 +164,7 @@ export class MdRenameProvider extends Disposable {
 		for (const ref of allRefsInfo.references) {
 			if (ref.kind === MdReferenceKind.Link) {
 				// Try to preserve style of existing links
-				const newLinkText = getLinkRenameText(this.workspace, ref.link.source, rawNewFilePath.path, newName.startsWith('./') || newName.startsWith('.\\'));
+				const newLinkText = getLinkRenameText(this.workspace, ref.link.source, rawNewFilePath.resource, newName.startsWith('./') || newName.startsWith('.\\'));
 				builder.replace(ref.link.source.resource, getFilePathRange(ref.link), encodeURI((newLinkText ?? newName).replace(/\\/g, '/')));
 			}
 		}
@@ -255,7 +255,7 @@ export function getLinkRenameText(workspace: IWorkspace, source: MdLinkSource, n
 			return undefined;
 		}
 
-		return '/' + path.relative(root.path.toString(true), newPath.toString(true));
+		return '/' + path.relative(root.resource.toString(true), newPath.toString(true));
 	}
 
 	const rootDir = Utils.dirname(source.resource);

--- a/src/tableOfContents.ts
+++ b/src/tableOfContents.ts
@@ -188,8 +188,8 @@ export class MdTableOfContentsProvider extends Disposable {
 	private readonly _cache: MdDocumentInfoCache<TableOfContents>;
 
 	constructor(
-		parser: IMdParser,
-		workspace: IWorkspace,
+		private readonly parser: IMdParser,
+		private readonly workspace: IWorkspace,
 		private readonly logger: ILogger,
 	) {
 		super();
@@ -205,5 +205,9 @@ export class MdTableOfContentsProvider extends Disposable {
 
 	public getForDocument(doc: ITextDocument): Promise<TableOfContents> {
 		return this._cache.getForDocument(doc);
+	}
+
+	public getForContainingDoc(doc: ITextDocument): Promise<TableOfContents> {
+		return TableOfContents.createForContainingDoc(this.parser, this.workspace, doc);
 	}
 }


### PR DESCRIPTION
Fixes #2

Switches the doc link provider to use normal uris in most cases

In cases where we need to use `vscode.open`, we instead use a new proxy command that clients must register (this command should forward to `vscode.open`)

This is done as it forces `vscode.open` to be executed on the exthost side instead of in core