### PR TITLE
Fix image reference links and use custom command for rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.0-alpha.3 — September 13, 2022
+- Fix detection of image reference links.
+- Use custom command name for triggering rename.
+
 ## 0.1.0-alpha.2 — September 7, 2022
 - Make document links use more generic commands instead of internal VS Code commands.
 - Fix document links within notebooks.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-markdown-languageservice",
   "description": "Markdown language service",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "engines": {

--- a/src/languageFeatures/codeActions/extractLinkDef.ts
+++ b/src/languageFeatures/codeActions/extractLinkDef.ts
@@ -98,15 +98,15 @@ export class MdExtractLinkDefinitionCodeActionProvider {
 			builder.insert(resource, { line: defBlock.endLine, character: line.length }, `\n[${placeholder}]: ${definitionText}`);
 		}
 
-		const renamePosition = translatePosition(targetLink.source.targetRange.start, { characterDelta: 2 });
+		const renamePosition = translatePosition(targetLink.source.targetRange.start, { characterDelta: 1 });
 		return {
 			title: MdExtractLinkDefinitionCodeActionProvider.genericTitle,
 			kind: MdExtractLinkDefinitionCodeActionProvider.kind,
 			edit: builder.getEdit(),
 			command: {
-				command: 'editor.action.rename',
+				command: 'vscodeMarkdownLanguageservice.rename',
 				title: 'Rename',
-				arguments: [doc.uri, renamePosition],
+				arguments: [URI.parse(doc.uri), renamePosition],
 			}
 		};
 	}

--- a/src/test/documentLinks.test.ts
+++ b/src/test/documentLinks.test.ts
@@ -34,7 +34,7 @@ suite('Link computer', () => {
 	}
 
 	function assertLinksEqual(actualLinks: readonly MdLink[], expected: ReadonlyArray<lsp.Range | { readonly range: lsp.Range; readonly sourceText: string }>) {
-		assert.strictEqual(actualLinks.length, expected.length);
+		assert.strictEqual(actualLinks.length, expected.length, 'Link counts should match');
 
 		for (let i = 0; i < actualLinks.length; ++i) {
 			const exp = expected[i];
@@ -180,6 +180,24 @@ suite('Link computer', () => {
 				makeRange(0, 39, 0, 47),
 			]);
 		}
+	});
+
+	test('Should not find empty reference link', async () => {
+		{
+			const links = await getLinksForText('[][]');
+			assertLinksEqual(links, []);
+		}
+		{
+			const links = await getLinksForText('[][cat]');
+			assertLinksEqual(links, []);
+		}
+	});
+
+	test('Should find image reference links', async () => {
+		const links = await getLinksForText('![][cat]');
+		assertLinksEqual(links, [
+			makeRange(0, 4, 0, 7),
+		]);
 	});
 
 	test('Should not consider link references starting with ^ character valid (#107471)', async () => {
@@ -493,7 +511,6 @@ suite('Link computer', () => {
 	});
 
 	test('Should find link within angle brackets even with space inside link.', async () => {
-
 		const links = await getLinksForText(joinLines(
 			`[link](<pa th>)`
 		));


### PR DESCRIPTION
- Using `editor.action.rename` directly causes VS Code to evaluate the command without converting the types properly. Instead we need to use a proxy command to handle this

- Also fixes detection of image reference links when the text is empty. This type of link is not normally valid but is supported for images