### PR TITLE
Fix false positive diagnostic with files that link to themselves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.0-alpha.4 — September 14, 2022
+- Fix false positive diagnostic with files that link to themselves.
+
 ## 0.1.0-alpha.3 — September 13, 2022
 - Fix detection of image reference links.
 - Use custom command name for triggering rename.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-markdown-languageservice",
   "description": "Markdown language service",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "engines": {

--- a/src/languageFeatures/diagnostics.ts
+++ b/src/languageFeatures/diagnostics.ts
@@ -114,6 +114,9 @@ export class DiagnosticComputer {
 			return { links, diagnostics: [], statCache };
 		}
 
+		// Current doc always implicitly exists
+		statCache.set(URI.parse(doc.uri), { exists: true });
+
 		return {
 			links: links,
 			statCache,


### PR DESCRIPTION
This fixes a tricky diagnostics case where we were incorrectly marking a document as not existing because it was the document that triggered the diagnostics request 