### PR TITLE
Add disposeDocumentResources method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.0-alpha.5 — September 14, 2022
+- Add `IPullDiagnosticsManager.disposeDocumentResources` to clean up watchers when a file is closed in the editor.
+
 ## 0.1.0-alpha.4 — September 14, 2022
 - Fix false positive diagnostic with files that link to themselves.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-markdown-languageservice",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-markdown-languageservice",
-      "version": "0.1.0-alpha.2",
+      "version": "0.1.0-alpha.5",
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-markdown-languageservice",
   "description": "Markdown language service",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "engines": {

--- a/src/languageFeatures/diagnostics.ts
+++ b/src/languageFeatures/diagnostics.ts
@@ -279,6 +279,14 @@ export interface IPullDiagnosticsManager extends IDisposable {
 	 * Compute the current diagnostics for a file.
 	 */
 	computeDiagnostics(doc: ITextDocument, options: DiagnosticOptions, token: CancellationToken): Promise<lsp.Diagnostic[]>;
+
+	/**
+	 * Clean up resources that help provide diagnostics for a document. 
+	 * 
+	 * You should call this when you will no longer be making diagnostic requests for a document, for example
+	 * when the file has been closed in the editor (but still exists on disk).
+	 */
+	disposeDocumentResources(document: URI): void;
 }
 
 class FileLinkState extends Disposable {
@@ -454,7 +462,7 @@ export class DiagnosticsManager extends Disposable implements IPullDiagnosticsMa
 		}));
 	}
 
-	async computeDiagnostics(doc: ITextDocument, options: DiagnosticOptions, token: CancellationToken): Promise<lsp.Diagnostic[]> {
+	public async computeDiagnostics(doc: ITextDocument, options: DiagnosticOptions, token: CancellationToken): Promise<lsp.Diagnostic[]> {
 		const uri = URI.parse(doc.uri);
 
 		const results = await this._computer.compute(doc, options, token);
@@ -464,5 +472,9 @@ export class DiagnosticsManager extends Disposable implements IPullDiagnosticsMa
 
 		this._linkWatcher.updateLinksForDocument(uri, results.links, results.statCache);
 		return results.diagnostics;
+	}
+
+	public disposeDocumentResources(uri: URI): void {
+		this._linkWatcher.deleteDocument(uri);
 	}
 }


### PR DESCRIPTION
This adds a new `disposeDocumentResources` method for the diagnostics manager to clean up watchers when a document is closed by the editor