### PR TITLE
Allow underscores in headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.0-alpha.6 — September 16, 2022
+- Use parsed markdown to generate header slugs instead of using the original text.
+
 ## 0.1.0-alpha.5 — September 14, 2022
 - Add `IPullDiagnosticsManager.disposeDocumentResources` to clean up watchers when a file is closed in the editor.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-markdown-languageservice",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-markdown-languageservice",
-      "version": "0.1.0-alpha.5",
+      "version": "0.1.0-alpha.6",
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-markdown-languageservice",
   "description": "Markdown language service",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "engines": {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -11,6 +11,7 @@ export interface Token {
 	readonly markup: string;
 	readonly content: string;
 	readonly map: number[] | null;
+	readonly children: readonly Token[] | null;
 }
 
 export interface TokenWithMap extends Token {

--- a/src/slugify.ts
+++ b/src/slugify.ts
@@ -24,7 +24,7 @@ export const githubSlugifier: ISlugifier = new class implements ISlugifier {
 				.toLowerCase()
 				.replace(/\s+/g, '-') // Replace whitespace with -
 				// allow-any-unicode-next-line
-				.replace(/[\]\[\!\/\'\"\#\$\%\&\(\)\*\+\,\.\/\:\;\<\=\>\?\@\\\^\_\{\|\}\~\`。，、；：？！…—·ˉ¨‘’“”々～‖∶＂＇｀｜〃〔〕〈〉《》「」『』．〖〗【】（）［］｛｝]/g, '') // Remove known punctuators
+				.replace(/[\]\[\!\/\'\"\#\$\%\&\(\)\*\+\,\.\/\:\;\<\=\>\?\@\\\^\{\|\}\~\`。，、；：？！…—·ˉ¨‘’“”々～‖∶＂＇｀｜〃〔〕〈〉《》「」『』．〖〗【】（）［］｛｝]/g, '') // Remove known punctuators
 				.replace(/^-+/, '') // Remove leading -
 				.replace(/-+$/, '') // Remove trailing -
 		);

--- a/src/test/references.test.ts
+++ b/src/test/references.test.ts
@@ -110,7 +110,7 @@ suite('References', () => {
 		const doc = new InMemoryDocument(workspacePath('doc.md'), joinLines(
 			`# a B c`,
 			`[simple](#a-b-c)`,
-			`[start underscore](#_a-b-c)`,
+			`[start underscore](#a-b-c)`,
 			`[different case](#a-B-C)`,
 		));
 		const workspace = store.add(new InMemoryWorkspace([doc]));


### PR DESCRIPTION
Fixes #48

Updates our slugifier to allow underscores

Also switches to use the parsed markdown to generate the header slug instead of using the source text