### PR TITLE
Don't validate line number links

### DIFF
--- a/src/languageFeatures/diagnostics.ts
+++ b/src/languageFeatures/diagnostics.ts
@@ -18,7 +18,7 @@ import { looksLikeMarkdownPath } from '../util/file';
 import { Limiter } from '../util/limiter';
 import { ResourceMap } from '../util/resourceMap';
 import { FileStat, IWorkspace, IWorkspaceWithWatching as IWorkspaceWithFileWatching, statLinkToMarkdownFile } from '../workspace';
-import { HrefKind, InternalHref, LinkDefinitionSet, MdLink, MdLinkProvider, MdLinkSource } from './documentLinks';
+import { HrefKind, InternalHref, LinkDefinitionSet, MdLink, MdLinkProvider, MdLinkSource, parseLocationInfoFromFragment } from './documentLinks';
 
 const localize = nls.loadMessageBundle();
 
@@ -141,12 +141,18 @@ export class DiagnosticComputer {
 
 		const diagnostics: lsp.Diagnostic[] = [];
 		for (const link of links) {
+
 			if (link.href.kind === HrefKind.Internal
 				&& link.source.hrefText.startsWith('#')
 				&& link.href.path.toString() === doc.uri.toString()
 				&& link.href.fragment
 				&& !toc.lookup(link.href.fragment)
 			) {
+				// Don't validate line number links
+				if (parseLocationInfoFromFragment(link.href.fragment)) {
+					continue;
+				}
+				
 				if (!this.isIgnoredLink(options, link.source.hrefText)) {
 					diagnostics.push({
 						code: DiagnosticCode.link_noSuchHeaderInOwnFile,
@@ -235,6 +241,11 @@ export class DiagnosticComputer {
 						if (fragmentLinks.length) {
 							const toc = await this.tocProvider.get(resolvedHrefPath);
 							for (const link of fragmentLinks) {
+								// Don't validate line number links
+								if (parseLocationInfoFromFragment(link.fragment)) {
+									continue;
+								}
+
 								if (!toc.lookup(link.fragment) && !this.isIgnoredLink(options, link.source.pathText) && !this.isIgnoredLink(options, link.source.hrefText)) {
 									const range = (link.source.fragmentRange && modifyRange(link.source.fragmentRange, translatePosition(link.source.fragmentRange.start, { characterDelta: -1 }), undefined)) ?? link.source.hrefRange;
 									diagnostics.push({

--- a/src/test/diagnostic.test.ts
+++ b/src/test/diagnostic.test.ts
@@ -385,6 +385,19 @@ suite('Diagnostic Computer', () => {
 		assert.strictEqual(diag1.data.fsPath, workspacePath('no such.md').fsPath);
 		assert.strictEqual(diag2.data.fsPath, workspacePath('no such.md').fsPath);
 	}));
+
+	test('Should not validate line number links', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('doc1.md'), joinLines(
+			`[link](#L1)`,
+			`[link](doc1.md#L1)`,
+			`[link](#L1,2)`,
+			`[link](doc1.md#L1,2)`,
+		));
+		const workspace = store.add(new InMemoryWorkspace([doc]));
+
+		const diagnostics = await getComputedDiagnostics(store, doc, workspace);
+		assertDiagnosticsEqual(diagnostics, []);
+	}));
 });
 
 


### PR DESCRIPTION
Stops us from trying to check if there is a heading `#L123` for links such as `[text](#L123)` which are links to line numbers