### PR TITLE
Make sure we cancel computations in more cases

### DIFF
--- a/src/languageFeatures/diagnostics.ts
+++ b/src/languageFeatures/diagnostics.ts
@@ -356,6 +356,10 @@ export class DiagnosticComputer {
 					}
 
 					const resolvedHrefPath = await statLinkToMarkdownFile(this.configuration, this.workspace, path, statCache);
+					if (token.isCancellationRequested) {
+						return;
+					}
+
 					if (!resolvedHrefPath) {
 						for (const link of links) {
 							if (!this.isIgnoredLink(options, link.source.pathText)) {
@@ -376,6 +380,10 @@ export class DiagnosticComputer {
 						const fragmentLinks = links.filter(x => x.fragment);
 						if (fragmentLinks.length) {
 							const toc = await this.tocProvider.get(resolvedHrefPath);
+							if (token.isCancellationRequested) {
+								return;
+							}
+							
 							for (const link of fragmentLinks) {
 								// Don't validate line number links
 								if (parseLocationInfoFromFragment(link.fragment)) {

--- a/src/languageFeatures/documentHighlights.ts
+++ b/src/languageFeatures/documentHighlights.ts
@@ -12,7 +12,7 @@ import { translatePosition } from '../types/position';
 import { modifyRange, rangeContains } from '../types/range';
 import { ITextDocument } from '../types/textDocument';
 import { tryAppendMarkdownFileExtension } from '../workspace';
-import { HrefKind, InternalHref, looksLikeLinkToDoc, MdLink, MdLinkKind, MdLinkProvider } from './documentLinks';
+import { HrefKind, InternalHref, looksLikeLinkToResource, MdLink, MdLinkKind, MdLinkProvider } from './documentLinks';
 import { getFilePathRange } from './rename';
 
 export class MdDocumentHighlightProvider {
@@ -104,7 +104,7 @@ export class MdDocumentHighlightProvider {
 		}
 
 		for (const link of links) {
-			if (link.href.kind === HrefKind.Internal && looksLikeLinkToDoc(this.configuration, link.href, targetDoc)) {
+			if (link.href.kind === HrefKind.Internal && looksLikeLinkToResource(this.configuration, link.href, targetDoc)) {
 				if (link.source.fragmentRange && link.href.fragment.toLowerCase() === fragment) {
 					yield {
 						range: modifyRange(link.source.fragmentRange, translatePosition(link.source.fragmentRange.start, { characterDelta: -1 })),
@@ -118,7 +118,7 @@ export class MdDocumentHighlightProvider {
 	private *getHighlightsForLinkPath(path: URI, links: readonly MdLink[]): Iterable<lsp.DocumentHighlight> {
 		const targetDoc = tryAppendMarkdownFileExtension(this.configuration, path) ?? path;
 		for (const link of links) {
-			if (link.href.kind === HrefKind.Internal && looksLikeLinkToDoc(this.configuration, link.href, targetDoc)) {
+			if (link.href.kind === HrefKind.Internal && looksLikeLinkToResource(this.configuration, link.href, targetDoc)) {
 				yield {
 					range: getFilePathRange(link),
 					kind: lsp.DocumentHighlightKind.Read,

--- a/src/languageFeatures/pathCompletions.ts
+++ b/src/languageFeatures/pathCompletions.ts
@@ -279,7 +279,7 @@ export class MdPathCompletionProvider {
 	}
 
 	private async *provideHeaderSuggestions(document: ITextDocument, position: lsp.Position, context: PathCompletionContext, insertionRange: lsp.Range, token: CancellationToken): AsyncIterable<lsp.CompletionItem> {
-		const toc = await TableOfContents.createForContainingDoc(this.parser, this.workspace, document);
+		const toc = await TableOfContents.createForContainingDoc(this.parser, this.workspace, document, token);
 		if (token.isCancellationRequested) {
 			return;
 		}

--- a/src/languageFeatures/workspaceSymbols.ts
+++ b/src/languageFeatures/workspaceSymbols.ts
@@ -6,7 +6,6 @@
 import { CancellationToken } from 'vscode-languageserver';
 import * as lsp from 'vscode-languageserver-types';
 import { ITextDocument } from '../types/textDocument';
-import { noopToken } from '../util/cancellation';
 import { Disposable } from '../util/dispose';
 import { IWorkspace } from '../workspace';
 import { MdWorkspaceInfoCache } from '../workspaceCache';
@@ -22,7 +21,7 @@ export class MdWorkspaceSymbolProvider extends Disposable {
 	) {
 		super();
 
-		this._cache = this._register(new MdWorkspaceInfoCache(workspace, doc => this.provideDocumentSymbolInformation(doc, noopToken)));
+		this._cache = this._register(new MdWorkspaceInfoCache(workspace, (doc, token) => this.provideDocumentSymbolInformation(doc, token)));
 	}
 
 	public async provideWorkspaceSymbols(query: string, token: CancellationToken): Promise<lsp.WorkspaceSymbol[]> {

--- a/src/test/tableOfContents.test.ts
+++ b/src/test/tableOfContents.test.ts
@@ -7,6 +7,7 @@ import * as assert from 'assert';
 import { URI } from 'vscode-uri';
 import { TableOfContents } from '../tableOfContents';
 import { ITextDocument } from '../types/textDocument';
+import { noopToken } from '../util/cancellation';
 import { createNewMarkdownEngine } from './engine';
 import { InMemoryDocument } from './inMemoryDocument';
 import { joinLines } from './util';
@@ -16,7 +17,7 @@ const testFileName = URI.file('test.md');
 
 function createToc(doc: ITextDocument): Promise<TableOfContents> {
 	const engine = createNewMarkdownEngine();
-	return TableOfContents.create(engine, doc);
+	return TableOfContents.create(engine, doc, noopToken);
 }
 
 suite('Table of contents', () => {

--- a/src/test/workspaceCache.test.ts
+++ b/src/test/workspaceCache.test.ts
@@ -84,8 +84,9 @@ suite('Workspace Cache', () => {
 		}
 	}));
 
-	test('Should cancel computation when document changes', withStore(async (_store) => {
-		const doc = new InMemoryDocument(workspacePath('doc.md'), 'abc');
+	test('Should cancel computation when document is deleted', withStore(async (_store) => {
+		const docUri = workspacePath('doc.md');
+		const doc = new InMemoryDocument(docUri, 'abc');
 		const workspace = new InMemoryWorkspace([doc]);
 
 		let didCancel = false;
@@ -98,10 +99,8 @@ suite('Workspace Cache', () => {
 
 		const req = cache.getForDocs([doc]); // Trigger compute
 
-		// Update doc should cancel pending compute
-		doc.updateContent('xyz');
-		workspace.updateDocument(doc);
-
+		// Delete doc should cancel pending compute
+		workspace.deleteDocument(docUri);
 
 		assert.deepStrictEqual(await req, ['cancelled']);
 		assert.deepStrictEqual(didCancel, true);


### PR DESCRIPTION
This makes the workspace cache able to cancel its computations when the file we are asking about is deleted. This is important as trying to compute values for deleted files will often throw exceptions

This also makes us observe the cancellation token in more spots