### PR TITLE
Adopt basic naming rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,21 @@ module.exports = {
 		'@typescript-eslint/no-unused-vars': 0,
 		'no-useless-escape': 0,
 		'semi': 1,
-		'quotes': [1, 'single', { allowTemplateLiterals: true }]
+		'quotes': [1, 'single', { allowTemplateLiterals: true }],
+		'@typescript-eslint/naming-convention': [
+			'warn',
+			{
+				'selector': 'default',
+				'modifiers': ['private'],
+				'format': null,
+				'leadingUnderscore': 'require'
+			},
+			{
+				'selector': 'default',
+				'modifiers': ['public'],
+				'format': null,
+				'leadingUnderscore': 'forbid'
+			}
+		],
 	},
 };

--- a/src/languageFeatures/codeActions/removeLinkDefinition.ts
+++ b/src/languageFeatures/codeActions/removeLinkDefinition.ts
@@ -17,11 +17,11 @@ const localize = nls.loadMessageBundle();
 
 export class MdRemoveLinkDefinitionCodeActionProvider {
 
-	private static readonly removeUnusedDefTitle = localize('removeUnusedTitle', 'Remove unused link definition');
-	private static readonly removeDuplicateDefTitle = localize('removeDuplicateTitle', 'Remove duplicate link definition');
+	private static readonly _removeUnusedDefTitle = localize('removeUnusedTitle', 'Remove unused link definition');
+	private static readonly _removeDuplicateDefTitle = localize('removeDuplicateTitle', 'Remove duplicate link definition');
 
 	*getActions(doc: ITextDocument, range: lsp.Range, context: lsp.CodeActionContext): Iterable<lsp.CodeAction> {
-		if (!this.isEnabled(context)) {
+		if (!this._isEnabled(context)) {
 			return;
 		}
 
@@ -30,7 +30,7 @@ export class MdRemoveLinkDefinitionCodeActionProvider {
 		for (const diag of context.diagnostics) {
 			if (diag.code === DiagnosticCode.link_unusedDefinition && diag.data && rangeIntersects(diag.range, range)) {
 				const link = diag.data as MdLinkDefinition;
-				yield this.getRemoveDefinitionAction(doc, link, MdRemoveLinkDefinitionCodeActionProvider.removeUnusedDefTitle);
+				yield this._getRemoveDefinitionAction(doc, link, MdRemoveLinkDefinitionCodeActionProvider._removeUnusedDefTitle);
 				unusedDiagnosticLines.add(link.source.range.start.line);
 			}
 		}
@@ -39,13 +39,13 @@ export class MdRemoveLinkDefinitionCodeActionProvider {
 			if (diag.code === DiagnosticCode.link_duplicateDefinition && diag.data && rangeIntersects(diag.range, range)) {
 				const link = diag.data as MdLinkDefinition;
 				if (!unusedDiagnosticLines.has(link.source.range.start.line)) {
-					yield this.getRemoveDefinitionAction(doc, link, MdRemoveLinkDefinitionCodeActionProvider.removeDuplicateDefTitle);
+					yield this._getRemoveDefinitionAction(doc, link, MdRemoveLinkDefinitionCodeActionProvider._removeDuplicateDefTitle);
 				}
 			}
 		}
 	}
 
-	private isEnabled(context: lsp.CodeActionContext): boolean {
+	private _isEnabled(context: lsp.CodeActionContext): boolean {
 		if (typeof context.only === 'undefined') {
 			return true;
 		}
@@ -53,12 +53,12 @@ export class MdRemoveLinkDefinitionCodeActionProvider {
 		return context.only.some(kind => codeActionKindContains(lsp.CodeActionKind.QuickFix, kind));
 	}
 
-	private getRemoveDefinitionAction(doc: ITextDocument, definition: MdLinkDefinition, title: string): lsp.CodeAction {
+	private _getRemoveDefinitionAction(doc: ITextDocument, definition: MdLinkDefinition, title: string): lsp.CodeAction {
 		const builder = new WorkspaceEditBuilder();
 
 		const range = definition.source.range;
 		builder.replace(URI.parse(doc.uri), makeRange(range.start.line, 0, range.start.line + 1, 0), '');
 
-		return { title, kind: lsp.CodeActionKind.QuickFix, edit: builder.getEdit() };
+		return { title, kind: lsp.CodeActionKind.QuickFix, edit: builder.renameFragment() };
 	}
 }

--- a/src/languageFeatures/documentHighlights.ts
+++ b/src/languageFeatures/documentHighlights.ts
@@ -18,31 +18,31 @@ import { getFilePathRange } from './rename';
 export class MdDocumentHighlightProvider {
 
 	constructor(
-		private readonly configuration: LsConfiguration,
-		private readonly tocProvider: MdTableOfContentsProvider,
-		private readonly linkProvider: MdLinkProvider,
+		private readonly _configuration: LsConfiguration,
+		private readonly _tocProvider: MdTableOfContentsProvider,
+		private readonly _linkProvider: MdLinkProvider,
 	) { }
 
 	public async getDocumentHighlights(document: ITextDocument, position: lsp.Position, token: CancellationToken): Promise<lsp.DocumentHighlight[]> {
-		const toc = await this.tocProvider.getForDocument(document);
+		const toc = await this._tocProvider.getForDocument(document);
 		if (token.isCancellationRequested) {
 			return [];
 		}
 
-		const { links } = await this.linkProvider.getLinks(document);
+		const { links } = await this._linkProvider.getLinks(document);
 		if (token.isCancellationRequested) {
 			return [];
 		}
 
 		const header = toc.entries.find(entry => entry.line === position.line);
 		if (header) {
-			return [...this.getHighlightsForHeader(document, header, links, toc)];
+			return [...this._getHighlightsForHeader(document, header, links, toc)];
 		}
 
-		return [...this.getHighlightsForLinkAtPosition(document, position, links, toc)];
+		return [...this._getHighlightsForLinkAtPosition(document, position, links, toc)];
 	}
 
-	private *getHighlightsForHeader(document: ITextDocument, header: TocEntry, links: readonly MdLink[], toc: TableOfContents): Iterable<lsp.DocumentHighlight> {
+	private *_getHighlightsForHeader(document: ITextDocument, header: TocEntry, links: readonly MdLink[], toc: TableOfContents): Iterable<lsp.DocumentHighlight> {
 		yield { range: header.headerLocation.range, kind: lsp.DocumentHighlightKind.Write };
 
 		const docUri = document.uri.toString();
@@ -60,7 +60,7 @@ export class MdDocumentHighlightProvider {
 		}
 	}
 
-	private getHighlightsForLinkAtPosition(document: ITextDocument, position: lsp.Position, links: readonly MdLink[], toc: TableOfContents): Iterable<lsp.DocumentHighlight> {
+	private _getHighlightsForLinkAtPosition(document: ITextDocument, position: lsp.Position, links: readonly MdLink[], toc: TableOfContents): Iterable<lsp.DocumentHighlight> {
 		const link = links.find(link => rangeContains(link.source.hrefRange, position) || (link.kind === MdLinkKind.Definition && rangeContains(link.ref.range, position)));
 		if (!link) {
 			return [];
@@ -68,28 +68,28 @@ export class MdDocumentHighlightProvider {
 
 		if (link.kind === MdLinkKind.Definition && rangeContains(link.ref.range, position)) {
 			// We are on the reference text inside the link definition
-			return this.getHighlightsForReference(link.ref.text, links);
+			return this._getHighlightsForReference(link.ref.text, links);
 		}
 
 		switch (link.href.kind) {
 			case HrefKind.Reference: {
-				return this.getHighlightsForReference(link.href.ref, links);
+				return this._getHighlightsForReference(link.href.ref, links);
 			}
 			case HrefKind.Internal: {
 				if (link.source.fragmentRange && rangeContains(link.source.fragmentRange, position)) {
-					return this.getHighlightsForLinkFragment(document, link.href, links, toc);
+					return this._getHighlightsForLinkFragment(document, link.href, links, toc);
 				}
 
-				return this.getHighlightsForLinkPath(link.href.path, links);
+				return this._getHighlightsForLinkPath(link.href.path, links);
 			}
 			case HrefKind.External: {
-				return this.getHighlightsForExternalLink(link.href.uri, links);
+				return this._getHighlightsForExternalLink(link.href.uri, links);
 			}
 		}
 	}
 
-	private *getHighlightsForLinkFragment(document: ITextDocument, href: InternalHref, links: readonly MdLink[], toc: TableOfContents): Iterable<lsp.DocumentHighlight> {
-		const targetDoc = tryAppendMarkdownFileExtension(this.configuration, href.path);
+	private *_getHighlightsForLinkFragment(document: ITextDocument, href: InternalHref, links: readonly MdLink[], toc: TableOfContents): Iterable<lsp.DocumentHighlight> {
+		const targetDoc = tryAppendMarkdownFileExtension(this._configuration, href.path);
 		if (!targetDoc) {
 			return;
 		}
@@ -104,7 +104,7 @@ export class MdDocumentHighlightProvider {
 		}
 
 		for (const link of links) {
-			if (link.href.kind === HrefKind.Internal && looksLikeLinkToResource(this.configuration, link.href, targetDoc)) {
+			if (link.href.kind === HrefKind.Internal && looksLikeLinkToResource(this._configuration, link.href, targetDoc)) {
 				if (link.source.fragmentRange && link.href.fragment.toLowerCase() === fragment) {
 					yield {
 						range: modifyRange(link.source.fragmentRange, translatePosition(link.source.fragmentRange.start, { characterDelta: -1 })),
@@ -115,10 +115,10 @@ export class MdDocumentHighlightProvider {
 		}
 	}
 
-	private *getHighlightsForLinkPath(path: URI, links: readonly MdLink[]): Iterable<lsp.DocumentHighlight> {
-		const targetDoc = tryAppendMarkdownFileExtension(this.configuration, path) ?? path;
+	private *_getHighlightsForLinkPath(path: URI, links: readonly MdLink[]): Iterable<lsp.DocumentHighlight> {
+		const targetDoc = tryAppendMarkdownFileExtension(this._configuration, path) ?? path;
 		for (const link of links) {
-			if (link.href.kind === HrefKind.Internal && looksLikeLinkToResource(this.configuration, link.href, targetDoc)) {
+			if (link.href.kind === HrefKind.Internal && looksLikeLinkToResource(this._configuration, link.href, targetDoc)) {
 				yield {
 					range: getFilePathRange(link),
 					kind: lsp.DocumentHighlightKind.Read,
@@ -127,7 +127,7 @@ export class MdDocumentHighlightProvider {
 		}
 	}
 
-	private *getHighlightsForExternalLink(uri: URI, links: readonly MdLink[]): Iterable<lsp.DocumentHighlight> {
+	private *_getHighlightsForExternalLink(uri: URI, links: readonly MdLink[]): Iterable<lsp.DocumentHighlight> {
 		for (const link of links) {
 			if (link.href.kind === HrefKind.External && link.href.uri.toString() === uri.toString()) {
 				yield {
@@ -138,7 +138,7 @@ export class MdDocumentHighlightProvider {
 		}
 	}
 
-	private *getHighlightsForReference(ref: string, links: readonly MdLink[]): Iterable<lsp.DocumentHighlight> {
+	private *_getHighlightsForReference(ref: string, links: readonly MdLink[]): Iterable<lsp.DocumentHighlight> {
 		for (const link of links) {
 			if (link.kind === MdLinkKind.Definition && link.ref.text === ref) {
 				yield {

--- a/src/languageFeatures/documentSymbols.ts
+++ b/src/languageFeatures/documentSymbols.ts
@@ -26,28 +26,28 @@ export interface ProvideDocumentSymbolOptions {
 export class MdDocumentSymbolProvider {
 
 	constructor(
-		private readonly tocProvider: MdTableOfContentsProvider,
-		private readonly linkProvider: MdLinkProvider,
-		private readonly logger: ILogger,
+		private readonly _tocProvider: MdTableOfContentsProvider,
+		private readonly _linkProvider: MdLinkProvider,
+		private readonly _logger: ILogger,
 	) { }
 
 	public async provideDocumentSymbols(document: ITextDocument, options: ProvideDocumentSymbolOptions, token: CancellationToken): Promise<lsp.DocumentSymbol[]> {
-		this.logger.log(LogLevel.Trace, 'DocumentSymbolProvider', `provideDocumentSymbols — ${document.uri} ${document.version}`);
+		this._logger.log(LogLevel.Trace, 'DocumentSymbolProvider', `provideDocumentSymbols — ${document.uri} ${document.version}`);
 
-		const linkSymbols = await (options.includeLinkDefinitions ? this.provideLinkDefinitionSymbols(document, token) : []);
+		const linkSymbols = await (options.includeLinkDefinitions ? this._provideLinkDefinitionSymbols(document, token) : []);
 		if (token.isCancellationRequested) {
 			return [];
 		}
 
-		const toc = await this.tocProvider.getForDocument(document);
+		const toc = await this._tocProvider.getForDocument(document);
 		if (token.isCancellationRequested) {
 			return [];
 		}
 
-		return this.toSymbolTree(document, linkSymbols, toc);
+		return this._toSymbolTree(document, linkSymbols, toc);
 	}
 
-	private toSymbolTree(document: ITextDocument, linkSymbols: readonly lsp.DocumentSymbol[], toc: TableOfContents): lsp.DocumentSymbol[] {
+	private _toSymbolTree(document: ITextDocument, linkSymbols: readonly lsp.DocumentSymbol[], toc: TableOfContents): lsp.DocumentSymbol[] {
 		const root: MarkdownSymbol = {
 			level: -Infinity,
 			children: [],
@@ -55,24 +55,24 @@ export class MdDocumentSymbolProvider {
 			range: makeRange(0, 0, document.lineCount + 1, 0),
 		};
 		const additionalSymbols = [...linkSymbols];
-		this.buildTocSymbolTree(root, toc.entries, additionalSymbols);
+		this._buildTocSymbolTree(root, toc.entries, additionalSymbols);
 		// Put remaining link definitions into top level document instead of last header
 		root.children.push(...additionalSymbols);
 		return root.children;
 	}
 
-	private async provideLinkDefinitionSymbols(document: ITextDocument, token: CancellationToken): Promise<lsp.DocumentSymbol[]> {
-		const { links } = await this.linkProvider.getLinks(document);
+	private async _provideLinkDefinitionSymbols(document: ITextDocument, token: CancellationToken): Promise<lsp.DocumentSymbol[]> {
+		const { links } = await this._linkProvider.getLinks(document);
 		if (token.isCancellationRequested) {
 			return [];
 		}
 
 		return links
 			.filter(link => link.kind === MdLinkKind.Definition)
-			.map((link): lsp.DocumentSymbol => this.definitionToDocumentSymbol(link as MdLinkDefinition));
+			.map((link): lsp.DocumentSymbol => this._definitionToDocumentSymbol(link as MdLinkDefinition));
 	}
 
-	private definitionToDocumentSymbol(def: MdLinkDefinition): lsp.DocumentSymbol {
+	private _definitionToDocumentSymbol(def: MdLinkDefinition): lsp.DocumentSymbol {
 		return {
 			kind: lsp.SymbolKind.Constant,
 			name: `[${def.ref.text}]`,
@@ -81,7 +81,7 @@ export class MdDocumentSymbolProvider {
 		};
 	}
 
-	private buildTocSymbolTree(parent: MarkdownSymbol, entries: readonly TocEntry[], additionalSymbols: lsp.DocumentSymbol[]): void {
+	private _buildTocSymbolTree(parent: MarkdownSymbol, entries: readonly TocEntry[], additionalSymbols: lsp.DocumentSymbol[]): void {
 		if (entries.length) {
 			while (additionalSymbols.length && isBefore(additionalSymbols[0].range.end, entries[0].sectionLocation.range.start)) {
 				parent.children.push(additionalSymbols.shift()!);
@@ -93,7 +93,7 @@ export class MdDocumentSymbolProvider {
 		}
 
 		const entry = entries[0];
-		const symbol = this.tocToDocumentSymbol(entry);
+		const symbol = this._tocToDocumentSymbol(entry);
 		symbol.children = [];
 
 		while (entry.level <= parent.level) {
@@ -101,19 +101,19 @@ export class MdDocumentSymbolProvider {
 		}
 		parent.children.push(symbol);
 
-		this.buildTocSymbolTree({ level: entry.level, children: symbol.children, parent, range: entry.sectionLocation.range }, entries.slice(1), additionalSymbols);
+		this._buildTocSymbolTree({ level: entry.level, children: symbol.children, parent, range: entry.sectionLocation.range }, entries.slice(1), additionalSymbols);
 	}
 
-	private tocToDocumentSymbol(entry: TocEntry): lsp.DocumentSymbol {
+	private _tocToDocumentSymbol(entry: TocEntry): lsp.DocumentSymbol {
 		return {
-			name: this.getTocSymbolName(entry),
+			name: this._getTocSymbolName(entry),
 			kind: lsp.SymbolKind.String,
 			range: entry.sectionLocation.range,
 			selectionRange: entry.sectionLocation.range
 		};
 	}
 
-	private getTocSymbolName(entry: TocEntry): string {
+	private _getTocSymbolName(entry: TocEntry): string {
 		return '#'.repeat(entry.level) + ' ' + entry.text;
 	}
 }

--- a/src/languageFeatures/fileRename.ts
+++ b/src/languageFeatures/fileRename.ts
@@ -32,10 +32,10 @@ export interface FileRenameResponse {
 export class MdFileRenameProvider extends Disposable {
 
 	public constructor(
-		private readonly config: LsConfiguration,
-		private readonly workspace: IWorkspace,
-		private readonly linkCache: MdWorkspaceInfoCache<readonly MdLink[]>,
-		private readonly referencesProvider: MdReferencesProvider,
+		private readonly _config: LsConfiguration,
+		private readonly _workspace: IWorkspace,
+		private readonly _linkCache: MdWorkspaceInfoCache<readonly MdLink[]>,
+		private readonly _referencesProvider: MdReferencesProvider,
 	) {
 		super();
 	}
@@ -45,12 +45,12 @@ export class MdFileRenameProvider extends Disposable {
 		const participatingRenames: FileRename[] = [];
 
 		for (const edit of edits) {
-			const stat = await this.workspace.stat(edit.newUri);
+			const stat = await this._workspace.stat(edit.newUri);
 			if (token.isCancellationRequested) {
 				return undefined;
 			}
 
-			if (await (stat?.isDirectory ? this.addDirectoryRenameEdits(edit, builder, token) : this.addSingleFileRenameEdits(edit, edits, builder, token))) {
+			if (await (stat?.isDirectory ? this._addDirectoryRenameEdits(edit, builder, token) : this._addSingleFileRenameEdits(edit, edits, builder, token))) {
 				participatingRenames.push(edit);
 			}
 
@@ -59,14 +59,14 @@ export class MdFileRenameProvider extends Disposable {
 			}
 		}
 
-		return { participatingRenames, edit: builder.getEdit() };
+		return { participatingRenames, edit: builder.renameFragment() };
 	}
 
-	private async addSingleFileRenameEdits(edit: FileRename, allEdits: readonly FileRename[], builder: WorkspaceEditBuilder, token: CancellationToken): Promise<boolean> {
+	private async _addSingleFileRenameEdits(edit: FileRename, allEdits: readonly FileRename[], builder: WorkspaceEditBuilder, token: CancellationToken): Promise<boolean> {
 		let didParticipate = false;
 
 		// Update all references to the file
-		if (await this.addEditsForReferencesToFile(edit, builder, token)) {
+		if (await this._addEditsForReferencesToFile(edit, builder, token)) {
 			didParticipate = true;
 		}
 
@@ -75,16 +75,16 @@ export class MdFileRenameProvider extends Disposable {
 		}
 
 		// If the file moved was markdown, we also need to update links in the file itself
-		if (await this.tryAddEditsInSelf(edit, allEdits, builder)) {
+		if (await this._tryAddEditsInSelf(edit, allEdits, builder)) {
 			didParticipate = true;
 		}
 
 		return didParticipate;
 	}
 
-	private async addDirectoryRenameEdits(edit: FileRename, builder: WorkspaceEditBuilder, token: CancellationToken): Promise<boolean> {
+	private async _addDirectoryRenameEdits(edit: FileRename, builder: WorkspaceEditBuilder, token: CancellationToken): Promise<boolean> {
 		// First update every link that points to something in the moved dir
-		const allLinksInWorkspace = await this.linkCache.entries();
+		const allLinksInWorkspace = await this._linkCache.entries();
 		if (token.isCancellationRequested) {
 			return false;
 		}
@@ -103,7 +103,7 @@ export class MdFileRenameProvider extends Disposable {
 						path: path.posix.join(edit.newUri.path, relative)
 					});
 
-					if (this.addLinkRenameEdit(docUri, link, newUri, builder)) {
+					if (this._addLinkRenameEdit(docUri, link, newUri, builder)) {
 						didParticipate = true;
 						continue;
 					}
@@ -116,7 +116,7 @@ export class MdFileRenameProvider extends Disposable {
 						path: Utils.joinPath(edit.oldUri, path.posix.relative(edit.newUri.path, docUri.path)).path
 					});
 
-					const oldLink = resolveInternalDocumentLink(oldDocUri, link.source.hrefText, this.workspace);
+					const oldLink = resolveInternalDocumentLink(oldDocUri, link.source.hrefText, this._workspace);
 					if (oldLink) {
 						let newPathText: string;
 						if (isParentDir(edit.oldUri, oldLink.resource)) {
@@ -143,32 +143,32 @@ export class MdFileRenameProvider extends Disposable {
 	 * Try to add edits for when a markdown file has been renamed.
 	 * In this case we also need to update links within the file.
 	 */
-	private async tryAddEditsInSelf(edit: FileRename, allEdits: readonly FileRename[], builder: WorkspaceEditBuilder): Promise<boolean> {
-		if (!looksLikeMarkdownPath(this.config, edit.newUri)) {
+	private async _tryAddEditsInSelf(edit: FileRename, allEdits: readonly FileRename[], builder: WorkspaceEditBuilder): Promise<boolean> {
+		if (!looksLikeMarkdownPath(this._config, edit.newUri)) {
 			return false;
 		}
 
-		if (isExcludedPath(this.config, edit.newUri)) {
+		if (isExcludedPath(this._config, edit.newUri)) {
 			return false;
 		}
 
-		const doc = await this.workspace.openMarkdownDocument(edit.newUri);
+		const doc = await this._workspace.openMarkdownDocument(edit.newUri);
 		if (!doc) {
 			return false;
 		}
 
-		const links = (await this.linkCache.getForDocs([doc]))[0];
+		const links = (await this._linkCache.getForDocs([doc]))[0];
 
 		let didParticipate = false;
 		for (const link of links) {
-			if (await this.addEditsForLinksInSelf(doc, link, edit, allEdits, builder)) {
+			if (await this._addEditsForLinksInSelf(doc, link, edit, allEdits, builder)) {
 				didParticipate = true;
 			}
 		}
 		return didParticipate;
 	}
 
-	private async addEditsForLinksInSelf(doc: ITextDocument, link: MdLink, edit: FileRename, allEdits: readonly FileRename[], builder: WorkspaceEditBuilder): Promise<boolean> {
+	private async _addEditsForLinksInSelf(doc: ITextDocument, link: MdLink, edit: FileRename, allEdits: readonly FileRename[], builder: WorkspaceEditBuilder): Promise<boolean> {
 		if (link.href.kind !== HrefKind.Internal) {
 			return false;
 		}
@@ -184,7 +184,7 @@ export class MdFileRenameProvider extends Disposable {
 		}
 
 		// Resolve the link relative to the old file path
-		let oldLink = resolveInternalDocumentLink(edit.oldUri, link.source.hrefText, this.workspace);
+		let oldLink = resolveInternalDocumentLink(edit.oldUri, link.source.hrefText, this._workspace);
 		if (!oldLink) {
 			return false;
 		}
@@ -197,18 +197,18 @@ export class MdFileRenameProvider extends Disposable {
 			}
 		}
 
-		return this.addLinkRenameEdit(URI.parse(doc.uri), link, oldLink.resource, builder);
+		return this._addLinkRenameEdit(URI.parse(doc.uri), link, oldLink.resource, builder);
 	}
 
 	/**
 	 * Update links across the workspace for the new file name
 	 */
-	private async addEditsForReferencesToFile(edit: FileRename, builder: WorkspaceEditBuilder, token: CancellationToken): Promise<boolean> {
-		if (isExcludedPath(this.config, edit.newUri)) {
+	private async _addEditsForReferencesToFile(edit: FileRename, builder: WorkspaceEditBuilder, token: CancellationToken): Promise<boolean> {
+		if (isExcludedPath(this._config, edit.newUri)) {
 			return false;
 		}
 
-		const refs = await this.referencesProvider.getReferencesToFileInWorkspace(edit.oldUri, token);
+		const refs = await this._referencesProvider.getReferencesToFileInWorkspace(edit.oldUri, token);
 		if (token.isCancellationRequested) {
 			return false;
 		}
@@ -216,7 +216,7 @@ export class MdFileRenameProvider extends Disposable {
 		let didParticipate = false;
 		for (const ref of refs) {
 			if (ref.kind === MdReferenceKind.Link) {
-				if (this.addLinkRenameEdit(URI.parse(ref.location.uri), ref.link, edit.newUri, builder)) {
+				if (this._addLinkRenameEdit(URI.parse(ref.location.uri), ref.link, edit.newUri, builder)) {
 					didParticipate = true;
 				}
 			}
@@ -224,7 +224,7 @@ export class MdFileRenameProvider extends Disposable {
 		return didParticipate;
 	}
 
-	private addLinkRenameEdit(doc: URI, link: MdLink, newUri: URI, builder: WorkspaceEditBuilder): boolean {
+	private _addLinkRenameEdit(doc: URI, link: MdLink, newUri: URI, builder: WorkspaceEditBuilder): boolean {
 		if (link.href.kind !== HrefKind.Internal) {
 			return false;
 		}
@@ -234,14 +234,14 @@ export class MdFileRenameProvider extends Disposable {
 		// If the original markdown link did not use a file extension, remove ours too
 		if (!Utils.extname(link.href.path)) {
 			const editExt = Utils.extname(newUri);
-			if (this.config.markdownFileExtensions.includes(editExt.replace('.', ''))) {
+			if (this._config.markdownFileExtensions.includes(editExt.replace('.', ''))) {
 				newFilePath = newUri.with({
 					path: newUri.path.slice(0, newUri.path.length - editExt.length)
 				});
 			}
 		}
 
-		const newLinkText = getLinkRenameText(this.workspace, link.source, newFilePath, link.source.pathText.startsWith('.'));
+		const newLinkText = getLinkRenameText(this._workspace, link.source, newFilePath, link.source.pathText.startsWith('.'));
 		if (typeof newLinkText === 'string') {
 			builder.replace(doc, getFilePathRange(link), encodeURI(newLinkText));
 			return true;

--- a/src/languageFeatures/folding.ts
+++ b/src/languageFeatures/folding.ts
@@ -16,24 +16,24 @@ const rangeLimit = 5000;
 export class MdFoldingProvider {
 
 	constructor(
-		private readonly parser: IMdParser,
-		private readonly tocProvider: MdTableOfContentsProvider,
-		private readonly logger: ILogger,
+		private readonly _parser: IMdParser,
+		private readonly _tocProvider: MdTableOfContentsProvider,
+		private readonly _logger: ILogger,
 	) { }
 
 	public async provideFoldingRanges(document: ITextDocument, token: CancellationToken): Promise<lsp.FoldingRange[]> {
-		this.logger.log(LogLevel.Debug, 'MdFoldingProvider', `provideFoldingRanges — ${document.uri} ${document.version}`);
+		this._logger.log(LogLevel.Debug, 'MdFoldingProvider', `provideFoldingRanges — ${document.uri} ${document.version}`);
 
 		const foldables = await Promise.all([
-			this.getRegions(document, token),
-			this.getHeaderFoldingRanges(document, token),
-			this.getBlockFoldingRanges(document, token)
+			this._getRegions(document, token),
+			this._getHeaderFoldingRanges(document, token),
+			this._getBlockFoldingRanges(document, token)
 		]);
 		return foldables.flat().slice(0, rangeLimit);
 	}
 
-	private async getRegions(document: ITextDocument, token: CancellationToken): Promise<lsp.FoldingRange[]> {
-		const tokens = await this.parser.tokenize(document);
+	private async _getRegions(document: ITextDocument, token: CancellationToken): Promise<lsp.FoldingRange[]> {
+		const tokens = await this._parser.tokenize(document);
 		if (token.isCancellationRequested) {
 			return [];
 		}
@@ -56,8 +56,8 @@ export class MdFoldingProvider {
 			.filter((region: lsp.FoldingRange | null): region is lsp.FoldingRange => !!region);
 	}
 
-	private async getHeaderFoldingRanges(document: ITextDocument, token: CancellationToken): Promise<lsp.FoldingRange[]> {
-		const toc = await this.tocProvider.getForDocument(document);
+	private async _getHeaderFoldingRanges(document: ITextDocument, token: CancellationToken): Promise<lsp.FoldingRange[]> {
+		const toc = await this._tocProvider.getForDocument(document);
 		if (token.isCancellationRequested) {
 			return [];
 		}
@@ -71,8 +71,8 @@ export class MdFoldingProvider {
 		});
 	}
 
-	private async getBlockFoldingRanges(document: ITextDocument, token: CancellationToken): Promise<lsp.FoldingRange[]> {
-		const tokens = await this.parser.tokenize(document);
+	private async _getBlockFoldingRanges(document: ITextDocument, token: CancellationToken): Promise<lsp.FoldingRange[]> {
+		const tokens = await this._parser.tokenize(document);
 		if (token.isCancellationRequested) {
 			return [];
 		}
@@ -84,11 +84,11 @@ export class MdFoldingProvider {
 			if (isEmptyOrWhitespace(getLine(document, end)) && end >= start + 1) {
 				end = end - 1;
 			}
-			return { startLine: start, endLine: end, kind: this.getFoldingRangeKind(listItem) };
+			return { startLine: start, endLine: end, kind: this._getFoldingRangeKind(listItem) };
 		});
 	}
 
-	private getFoldingRangeKind(listItem: Token): lsp.FoldingRangeKind | undefined {
+	private _getFoldingRangeKind(listItem: Token): lsp.FoldingRangeKind | undefined {
 		return listItem.type === 'html_block' && listItem.content.startsWith('<!--')
 			? lsp.FoldingRangeKind.Comment
 			: undefined;

--- a/src/languageFeatures/organizeLinkDefs.ts
+++ b/src/languageFeatures/organizeLinkDefs.ts
@@ -31,7 +31,7 @@ export class MdOrganizeLinkDefinitionProvider {
 		const edits: lsp.TextEdit[] = [];
 
 		// First replace all inline definitions that are not the definition block
-		for (const group of this.getDefinitionBlockGroups(doc, definitions)) {
+		for (const group of this._getDefinitionBlockGroups(doc, definitions)) {
 			if (!existingDefBlockRange || group.startLine < existingDefBlockRange.startLine) {
 				// Don't replace trailing newline of last definition in group
 				edits.push({
@@ -74,7 +74,7 @@ export class MdOrganizeLinkDefinitionProvider {
 				range: makeRange(existingDefBlockRange.startLine, 0, existingDefBlockRange.endLine, getLine(doc, existingDefBlockRange.endLine).length)
 			});
 		} else {
-			const line = this.getLastNonWhitespaceLine(doc, definitions);
+			const line = this._getLastNonWhitespaceLine(doc, definitions);
 			edits.push({
 				newText: (line === doc.lineCount - 1 ? '\n\n' : '\n') + defBlock,
 				range: makeRange(line + 1, 0, doc.lineCount, 0),
@@ -84,7 +84,7 @@ export class MdOrganizeLinkDefinitionProvider {
 		return edits;
 	}
 
-	private *getDefinitionBlockGroups(doc: ITextDocument, definitions: readonly MdLinkDefinition[]): Iterable<{ readonly startLine: number, readonly endLine: number }> {
+	private *_getDefinitionBlockGroups(doc: ITextDocument, definitions: readonly MdLinkDefinition[]): Iterable<{ readonly startLine: number, readonly endLine: number }> {
 		if (!definitions.length) {
 			return;
 		}
@@ -102,10 +102,10 @@ export class MdOrganizeLinkDefinitionProvider {
 		}
 
 		yield { startLine: startDef.source.range.start.line, endLine: endDef.source.range.start.line };
-		yield* this.getDefinitionBlockGroups(doc, definitions.slice(i + 1));
+		yield* this._getDefinitionBlockGroups(doc, definitions.slice(i + 1));
 	}
 
-	private getLastNonWhitespaceLine(doc: ITextDocument, orderedDefinitions: readonly MdLinkDefinition[]): number {
+	private _getLastNonWhitespaceLine(doc: ITextDocument, orderedDefinitions: readonly MdLinkDefinition[]): number {
 		const lastDef = orderedDefinitions[orderedDefinitions.length - 1];
 		const textAfter = doc.getText(makeRange(lastDef.source.range.end.line + 1, 0, Infinity, 0));
 		const lines = textAfter.split(/\r\n|\n/g);

--- a/src/languageFeatures/smartSelect.ts
+++ b/src/languageFeatures/smartSelect.ts
@@ -16,41 +16,41 @@ import { isEmptyOrWhitespace } from '../util/string';
 export class MdSelectionRangeProvider {
 
 	constructor(
-		private readonly parser: IMdParser,
-		private readonly tocProvider: MdTableOfContentsProvider,
-		private readonly logger: ILogger,
+		private readonly _parser: IMdParser,
+		private readonly _tocProvider: MdTableOfContentsProvider,
+		private readonly _logger: ILogger,
 	) { }
 
 	public async provideSelectionRanges(document: ITextDocument, positions: Position[], token: CancellationToken): Promise<lsp.SelectionRange[] | undefined> {
-		this.logger.log(LogLevel.Debug, 'MdSelectionRangeProvider', `provideSelectionRanges — ${document.uri} ${document.version}`);
+		this._logger.log(LogLevel.Debug, 'MdSelectionRangeProvider', `provideSelectionRanges — ${document.uri} ${document.version}`);
 
 		const promises = await Promise.all(positions.map((position) => {
-			return this.provideSelectionRange(document, position, token);
+			return this._provideSelectionRange(document, position, token);
 		}));
 		return promises.filter(item => item !== undefined) as lsp.SelectionRange[];
 	}
 
-	private async provideSelectionRange(document: ITextDocument, position: Position, token: CancellationToken): Promise<lsp.SelectionRange | undefined> {
-		const headerRange = await this.getHeaderSelectionRange(document, position);
+	private async _provideSelectionRange(document: ITextDocument, position: Position, token: CancellationToken): Promise<lsp.SelectionRange | undefined> {
+		const headerRange = await this._getHeaderSelectionRange(document, position);
 		if (token.isCancellationRequested) {
 			return;
 		}
 
-		const blockRange = await this.getBlockSelectionRange(document, position, headerRange);
+		const blockRange = await this._getBlockSelectionRange(document, position, headerRange);
 		if (token.isCancellationRequested) {
 			return;
 		}
 
-		const inlineRange = await this.getInlineSelectionRange(document, position, blockRange);
+		const inlineRange = await this._getInlineSelectionRange(document, position, blockRange);
 		return inlineRange || blockRange || headerRange;
 	}
 
-	private async getInlineSelectionRange(document: ITextDocument, position: Position, blockRange?: lsp.SelectionRange): Promise<lsp.SelectionRange | undefined> {
+	private async _getInlineSelectionRange(document: ITextDocument, position: Position, blockRange?: lsp.SelectionRange): Promise<lsp.SelectionRange | undefined> {
 		return createInlineRange(document, position, blockRange);
 	}
 
-	private async getBlockSelectionRange(document: ITextDocument, position: Position, headerRange?: lsp.SelectionRange): Promise<lsp.SelectionRange | undefined> {
-		const tokens = await this.parser.tokenize(document);
+	private async _getBlockSelectionRange(document: ITextDocument, position: Position, headerRange?: lsp.SelectionRange): Promise<lsp.SelectionRange | undefined> {
+		const tokens = await this._parser.tokenize(document);
 		const blockTokens = getBlockTokensForPosition(tokens, position, headerRange);
 
 		if (blockTokens.length === 0) {
@@ -65,8 +65,8 @@ export class MdSelectionRangeProvider {
 		return currentRange;
 	}
 
-	private async getHeaderSelectionRange(document: ITextDocument, position: Position): Promise<lsp.SelectionRange | undefined> {
-		const toc = await this.tocProvider.getForDocument(document);
+	private async _getHeaderSelectionRange(document: ITextDocument, position: Position): Promise<lsp.SelectionRange | undefined> {
+		const toc = await this._tocProvider.getForDocument(document);
 
 		const headerInfo = getHeadersForPosition(toc.entries, position);
 

--- a/src/languageFeatures/workspaceSymbols.ts
+++ b/src/languageFeatures/workspaceSymbols.ts
@@ -17,7 +17,7 @@ export class MdWorkspaceSymbolProvider extends Disposable {
 
 	public constructor(
 		workspace: IWorkspace,
-		private readonly symbolProvider: MdDocumentSymbolProvider,
+		private readonly _symbolProvider: MdDocumentSymbolProvider,
 	) {
 		super();
 
@@ -35,14 +35,14 @@ export class MdWorkspaceSymbolProvider extends Disposable {
 	}
 
 	public async provideDocumentSymbolInformation(document: ITextDocument, token: CancellationToken): Promise<lsp.SymbolInformation[]> {
-		const docSymbols = await this.symbolProvider.provideDocumentSymbols(document, {}, token);
+		const docSymbols = await this._symbolProvider.provideDocumentSymbols(document, {}, token);
 		if (token.isCancellationRequested) {
 			return [];
 		}
-		return Array.from(this.toSymbolInformation(document.uri, docSymbols));
+		return Array.from(this._toSymbolInformation(document.uri, docSymbols));
 	}
 
-	private *toSymbolInformation(uri: string, docSymbols: lsp.DocumentSymbol[]): Iterable<lsp.SymbolInformation> {
+	private *_toSymbolInformation(uri: string, docSymbols: lsp.DocumentSymbol[]): Iterable<lsp.SymbolInformation> {
 		for (const symbol of docSymbols) {
 			yield {
 				name: symbol.name,
@@ -50,7 +50,7 @@ export class MdWorkspaceSymbolProvider extends Disposable {
 				location: { uri, range: symbol.selectionRange }
 			};
 			if (symbol.children) {
-				yield* this.toSymbolInformation(uri, symbol.children);
+				yield* this._toSymbolInformation(uri, symbol.children);
 			}
 		}
 	}

--- a/src/test/inMemoryWorkspace.ts
+++ b/src/test/inMemoryWorkspace.ts
@@ -64,7 +64,7 @@ export class InMemoryWorkspace extends Disposable implements IWorkspaceWithWatch
 		}
 
 		const pathPrefix = resource.fsPath + (resource.fsPath.endsWith('/') || resource.fsPath.endsWith('\\') ? '' : path.sep);
-		const allPaths = this.getAllKnownFilePaths();
+		const allPaths = this._getAllKnownFilePaths();
 		if (allPaths.some(path => path.startsWith(pathPrefix))) {
 			return { isDirectory: true };
 		}
@@ -91,7 +91,7 @@ export class InMemoryWorkspace extends Disposable implements IWorkspaceWithWatch
 	public async readDirectory(resource: URI): Promise<[string, FileStat][]> {
 		const files = new Map<string, FileStat>();
 		const pathPrefix = resource.fsPath + (resource.fsPath.endsWith('/') || resource.fsPath.endsWith('\\') ? '' : path.sep);
-		const allPaths = this.getAllKnownFilePaths();
+		const allPaths = this._getAllKnownFilePaths();
 		for (const path of allPaths) {
 			if (path.startsWith(pathPrefix)) {
 				const parts = path.slice(pathPrefix.length).split(/\/|\\/g);
@@ -110,7 +110,7 @@ export class InMemoryWorkspace extends Disposable implements IWorkspaceWithWatch
 	private readonly _onDidDeleteMarkdownDocumentEmitter = this._register(new Emitter<URI>());
 	public onDidDeleteMarkdownDocument = this._onDidDeleteMarkdownDocumentEmitter.event;
 
-	private getAllKnownFilePaths(): string[] {
+	private _getAllKnownFilePaths(): string[] {
 		return [
 			...Array.from(this._documents.values(), doc => URI.parse(doc.uri).fsPath),
 			...Array.from(this._additionalFiles.keys(), uri => uri.fsPath),

--- a/src/util/cancellation.ts
+++ b/src/util/cancellation.ts
@@ -5,9 +5,9 @@
 
 import { CancellationToken, Emitter } from 'vscode-languageserver';
 
-export const noopToken = new class implements CancellationToken {
-	_onCancellationRequestedEmitter = new Emitter<void>();
+export const noopToken: CancellationToken = new class implements CancellationToken {
+	private readonly _onCancellationRequestedEmitter = new Emitter<void>();
 	onCancellationRequested = this._onCancellationRequestedEmitter.event;
 
 	get isCancellationRequested() { return false; }
-};
+}();

--- a/src/util/dispose.ts
+++ b/src/util/dispose.ts
@@ -65,12 +65,12 @@ export abstract class Disposable {
 }
 
 export class DisposableStore extends Disposable {
-	private readonly items = new Set<IDisposable>();
+	private readonly _items = new Set<IDisposable>();
 
 	public override dispose() {
 		super.dispose();
-		disposeAll(this.items);
-		this.items.clear();
+		disposeAll(this._items);
+		this._items.clear();
 	}
 
 	public add<T extends IDisposable>(item: T): T {
@@ -78,7 +78,7 @@ export class DisposableStore extends Disposable {
 			console.warn('Adding to disposed store. Item will be leaked');
 		}
 
-		this.items.add(item);
+		this._items.add(item);
 		return item;
 	}
 }

--- a/src/util/editBuilder.ts
+++ b/src/util/editBuilder.ts
@@ -8,40 +8,40 @@ import { URI } from 'vscode-uri';
 
 export class WorkspaceEditBuilder {
 
-	private readonly changes: { [uri: lsp.DocumentUri]: lsp.TextEdit[]; } = {};
-	private readonly documentChanges: Array<lsp.CreateFile | lsp.RenameFile | lsp.DeleteFile> = [];
+	private readonly _changes: { [uri: lsp.DocumentUri]: lsp.TextEdit[]; } = {};
+	private readonly _documentChanges: Array<lsp.CreateFile | lsp.RenameFile | lsp.DeleteFile> = [];
 
 	replace(resource: URI, range: lsp.Range, newText: string): void {
-		this.addEdit(resource, lsp.TextEdit.replace(range, newText));
+		this._addEdit(resource, lsp.TextEdit.replace(range, newText));
 	}
 
 	insert(resource: URI, position: lsp.Position, newText: string): void {
-		this.addEdit(resource, lsp.TextEdit.insert(position, newText));
+		this._addEdit(resource, lsp.TextEdit.insert(position, newText));
 	}
 
-	private addEdit(resource: URI, edit: lsp.TextEdit): void {
+	private _addEdit(resource: URI, edit: lsp.TextEdit): void {
 		const resourceKey = resource.toString();
-		let edits = this.changes![resourceKey];
+		let edits = this._changes![resourceKey];
 		if (!edits) {
 			edits = [];
-			this.changes![resourceKey] = edits;
+			this._changes![resourceKey] = edits;
 		}
 
 		edits.push(edit);
 	}
 
-	getEdit(): lsp.WorkspaceEdit {
+	renameFragment(): lsp.WorkspaceEdit {
 		// We need to convert changes into `documentChanges` or else they get dropped
-		const textualChanges = Object.entries(this.changes).map(([uri, edits]): lsp.TextDocumentEdit => {
+		const textualChanges = Object.entries(this._changes).map(([uri, edits]): lsp.TextDocumentEdit => {
 			return lsp.TextDocumentEdit.create({ uri, version: null }, edits);
 		});
 
 		return {
-			documentChanges: [...textualChanges, ...this.documentChanges],
+			documentChanges: [...textualChanges, ...this._documentChanges],
 		};
 	}
 
 	renameFile(targetUri: URI, resolvedNewFilePath: URI) {
-		this.documentChanges.push(lsp.RenameFile.create(targetUri.toString(), resolvedNewFilePath.toString()));
+		this._documentChanges.push(lsp.RenameFile.create(targetUri.toString(), resolvedNewFilePath.toString()));
 	}
 }

--- a/src/util/resourceMap.ts
+++ b/src/util/resourceMap.ts
@@ -12,53 +12,53 @@ const defaultResourceToKey = (resource: URI): string => resource.toString();
 
 export class ResourceMap<T> {
 
-	private readonly map = new Map<string, { readonly uri: URI; readonly value: T }>();
+	private readonly _map = new Map<string, { readonly uri: URI; readonly value: T }>();
 
-	private readonly toKey: ResourceToKey;
+	private readonly _toKey: ResourceToKey;
 
 	constructor(toKey: ResourceToKey = defaultResourceToKey) {
-		this.toKey = toKey;
+		this._toKey = toKey;
 	}
 
 	public set(uri: URI, value: T): this {
-		this.map.set(this.toKey(uri), { uri, value });
+		this._map.set(this._toKey(uri), { uri, value });
 		return this;
 	}
 
 	public get(resource: URI): T | undefined {
-		return this.map.get(this.toKey(resource))?.value;
+		return this._map.get(this._toKey(resource))?.value;
 	}
 
 	public has(resource: URI): boolean {
-		return this.map.has(this.toKey(resource));
+		return this._map.has(this._toKey(resource));
 	}
 
 	public get size(): number {
-		return this.map.size;
+		return this._map.size;
 	}
 
 	public clear(): void {
-		this.map.clear();
+		this._map.clear();
 	}
 
 	public delete(resource: URI): boolean {
-		return this.map.delete(this.toKey(resource));
+		return this._map.delete(this._toKey(resource));
 	}
 
 	public *values(): IterableIterator<T> {
-		for (const entry of this.map.values()) {
+		for (const entry of this._map.values()) {
 			yield entry.value;
 		}
 	}
 
 	public *keys(): IterableIterator<URI> {
-		for (const entry of this.map.values()) {
+		for (const entry of this._map.values()) {
 			yield entry.uri;
 		}
 	}
 
 	public *entries(): IterableIterator<[URI, T]> {
-		for (const entry of this.map.values()) {
+		for (const entry of this._map.values()) {
 			yield [entry.uri, entry.value];
 		}
 	}


### PR DESCRIPTION
Require `_` on privates and forbid it on publics