### PR TITLE
Use ES # privates instead of private keyword

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,20 +15,12 @@ module.exports = {
 		'no-useless-escape': 0,
 		'semi': 1,
 		'quotes': [1, 'single', { allowTemplateLiterals: true }],
-		'@typescript-eslint/naming-convention': [
+		'no-restricted-syntax': [
 			'warn',
 			{
-				'selector': 'default',
-				'modifiers': ['private'],
-				'format': null,
-				'leadingUnderscore': 'require'
+				selector: ':matches(PropertyDefinition, TSParameterProperty, MethodDefinition[key.name!="constructor"])[accessibility="private"]',
+				message: 'Use #private instead',
 			},
-			{
-				'selector': 'default',
-				'modifiers': ['public'],
-				'format': null,
-				'leadingUnderscore': 'forbid'
-			}
 		],
 	},
-};
+}; 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "api-extractor": "npx api-extractor run --local",
     "compile": "tsc -b tsconfig.json",
     "watch": "tsc -b tsconfig.json --watch",
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "prepublishOnly": "npm run compile && npm run api-extractor",
     "test": "mocha 'out/test/**/*.test.js' --ui=tdd --timeout=2000 --exit"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "api-extractor": "npx api-extractor run --local",
     "compile": "tsc -b tsconfig.json",
     "watch": "tsc -b tsconfig.json --watch",
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "prepublishOnly": "npm run compile && npm run api-extractor",
     "test": "mocha 'out/test/**/*.test.js' --ui=tdd --timeout=2000 --exit"
   },

--- a/src/languageFeatures/codeActions/removeLinkDefinition.ts
+++ b/src/languageFeatures/codeActions/removeLinkDefinition.ts
@@ -16,11 +16,11 @@ const localize = nls.loadMessageBundle();
 
 export class MdRemoveLinkDefinitionCodeActionProvider {
 
-	private static readonly _removeUnusedDefTitle = localize('removeUnusedTitle', 'Remove unused link definition');
-	private static readonly _removeDuplicateDefTitle = localize('removeDuplicateTitle', 'Remove duplicate link definition');
+	static readonly #removeUnusedDefTitle = localize('removeUnusedTitle', 'Remove unused link definition');
+	static readonly #removeDuplicateDefTitle = localize('removeDuplicateTitle', 'Remove duplicate link definition');
 
 	*getActions(doc: ITextDocument, range: lsp.Range, context: lsp.CodeActionContext): Iterable<lsp.CodeAction> {
-		if (!this._isEnabled(context)) {
+		if (!this.#isEnabled(context)) {
 			return;
 		}
 
@@ -29,7 +29,7 @@ export class MdRemoveLinkDefinitionCodeActionProvider {
 		for (const diag of context.diagnostics) {
 			if (diag.code === DiagnosticCode.link_unusedDefinition && diag.data && rangeIntersects(diag.range, range)) {
 				const link = diag.data as MdLinkDefinition;
-				yield this._getRemoveDefinitionAction(doc, link, MdRemoveLinkDefinitionCodeActionProvider._removeUnusedDefTitle);
+				yield this.#getRemoveDefinitionAction(doc, link, MdRemoveLinkDefinitionCodeActionProvider.#removeUnusedDefTitle);
 				unusedDiagnosticLines.add(link.source.range.start.line);
 			}
 		}
@@ -38,13 +38,13 @@ export class MdRemoveLinkDefinitionCodeActionProvider {
 			if (diag.code === DiagnosticCode.link_duplicateDefinition && diag.data && rangeIntersects(diag.range, range)) {
 				const link = diag.data as MdLinkDefinition;
 				if (!unusedDiagnosticLines.has(link.source.range.start.line)) {
-					yield this._getRemoveDefinitionAction(doc, link, MdRemoveLinkDefinitionCodeActionProvider._removeDuplicateDefTitle);
+					yield this.#getRemoveDefinitionAction(doc, link, MdRemoveLinkDefinitionCodeActionProvider.#removeDuplicateDefTitle);
 				}
 			}
 		}
 	}
 
-	private _isEnabled(context: lsp.CodeActionContext): boolean {
+	#isEnabled(context: lsp.CodeActionContext): boolean {
 		if (typeof context.only === 'undefined') {
 			return true;
 		}
@@ -52,7 +52,7 @@ export class MdRemoveLinkDefinitionCodeActionProvider {
 		return context.only.some(kind => codeActionKindContains(lsp.CodeActionKind.QuickFix, kind));
 	}
 
-	private _getRemoveDefinitionAction(doc: ITextDocument, definition: MdLinkDefinition, title: string): lsp.CodeAction {
+	#getRemoveDefinitionAction(doc: ITextDocument, definition: MdLinkDefinition, title: string): lsp.CodeAction {
 		const builder = new WorkspaceEditBuilder();
 
 		const range = definition.source.range;

--- a/src/languageFeatures/definitions.ts
+++ b/src/languageFeatures/definitions.ts
@@ -14,15 +14,25 @@ import { HrefKind, LinkDefinitionSet, MdLink, MdLinkKind } from './documentLinks
 
 export class MdDefinitionProvider {
 
+	readonly #configuration: LsConfiguration;
+	readonly #workspace: IWorkspace;
+	readonly #tocProvider: MdTableOfContentsProvider;
+	readonly #linkCache: MdWorkspaceInfoCache<readonly MdLink[]>;
+
 	constructor(
-		private readonly _configuration: LsConfiguration,
-		private readonly _workspace: IWorkspace,
-		private readonly _tocProvider: MdTableOfContentsProvider,
-		private readonly _linkCache: MdWorkspaceInfoCache<readonly MdLink[]>,
-	) { }
+		configuration: LsConfiguration,
+		workspace: IWorkspace,
+		tocProvider: MdTableOfContentsProvider,
+		linkCache: MdWorkspaceInfoCache<readonly MdLink[]>,
+	) {
+		this.#configuration = configuration;
+		this.#workspace = workspace;
+		this.#tocProvider = tocProvider;
+		this.#linkCache = linkCache;
+	}
 
 	async provideDefinition(document: ITextDocument, position: lsp.Position, token: CancellationToken): Promise<lsp.Definition | undefined> {
-		const toc = await this._tocProvider.getForDocument(document);
+		const toc = await this.#tocProvider.getForDocument(document);
 		if (token.isCancellationRequested) {
 			return [];
 		}
@@ -32,43 +42,43 @@ export class MdDefinitionProvider {
 			return header.headerLocation;
 		}
 
-		return this._getDefinitionOfLinkAtPosition(document, position, token);
+		return this.#getDefinitionOfLinkAtPosition(document, position, token);
 	}
 
-	private async _getDefinitionOfLinkAtPosition(document: ITextDocument, position: lsp.Position, token: CancellationToken): Promise<lsp.Definition | undefined> {
-		const docLinks = (await this._linkCache.getForDocs([document]))[0];
+	async #getDefinitionOfLinkAtPosition(document: ITextDocument, position: lsp.Position, token: CancellationToken): Promise<lsp.Definition | undefined> {
+		const docLinks = (await this.#linkCache.getForDocs([document]))[0];
 
 		for (const link of docLinks) {
 			if (link.kind === MdLinkKind.Definition && rangeContains(link.ref.range, position)) {
-				return this._getDefinitionOfRef(link.ref.text, docLinks);
+				return this.#getDefinitionOfRef(link.ref.text, docLinks);
 			}
 			if (rangeContains(link.source.hrefRange, position)) {
-				return this._getDefinitionOfLink(link, docLinks, token);
+				return this.#getDefinitionOfLink(link, docLinks, token);
 			}
 		}
 
 		return undefined;
 	}
 
-	private async _getDefinitionOfLink(sourceLink: MdLink, allLinksInFile: readonly MdLink[], token: CancellationToken): Promise<lsp.Definition | undefined> {
+	async #getDefinitionOfLink(sourceLink: MdLink, allLinksInFile: readonly MdLink[], token: CancellationToken): Promise<lsp.Definition | undefined> {
 		if (sourceLink.href.kind === HrefKind.Reference) {
-			return this._getDefinitionOfRef(sourceLink.href.ref, allLinksInFile);
+			return this.#getDefinitionOfRef(sourceLink.href.ref, allLinksInFile);
 		}
 
 		if (sourceLink.href.kind === HrefKind.External || !sourceLink.href.fragment) {
 			return undefined;
 		}
 
-		const resolvedResource = await statLinkToMarkdownFile(this._configuration, this._workspace, sourceLink.href.path);
+		const resolvedResource = await statLinkToMarkdownFile(this.#configuration, this.#workspace, sourceLink.href.path);
 		if (!resolvedResource || token.isCancellationRequested) {
 			return undefined;
 		}
 
-		const toc = await this._tocProvider.get(resolvedResource);
+		const toc = await this.#tocProvider.get(resolvedResource);
 		return toc.lookup(sourceLink.href.fragment)?.headerLocation;
 	}
 
-	private _getDefinitionOfRef(ref: string, allLinksInFile: readonly MdLink[]) {
+	#getDefinitionOfRef(ref: string, allLinksInFile: readonly MdLink[]) {
 		const allDefinitions = new LinkDefinitionSet(allLinksInFile);
 		const def = allDefinitions.lookup(ref);
 		return def ? { range: def.source.range, uri: def.source.resource.toString() } : undefined;

--- a/src/languageFeatures/documentSymbols.ts
+++ b/src/languageFeatures/documentSymbols.ts
@@ -25,29 +25,37 @@ export interface ProvideDocumentSymbolOptions {
 
 export class MdDocumentSymbolProvider {
 
+	readonly #tocProvider: MdTableOfContentsProvider;
+	readonly #linkProvider: MdLinkProvider;
+	readonly #logger: ILogger;
+
 	constructor(
-		private readonly _tocProvider: MdTableOfContentsProvider,
-		private readonly _linkProvider: MdLinkProvider,
-		private readonly _logger: ILogger,
-	) { }
-
-	public async provideDocumentSymbols(document: ITextDocument, options: ProvideDocumentSymbolOptions, token: CancellationToken): Promise<lsp.DocumentSymbol[]> {
-		this._logger.log(LogLevel.Trace, 'DocumentSymbolProvider', `provideDocumentSymbols — ${document.uri} ${document.version}`);
-
-		const linkSymbols = await (options.includeLinkDefinitions ? this._provideLinkDefinitionSymbols(document, token) : []);
-		if (token.isCancellationRequested) {
-			return [];
-		}
-
-		const toc = await this._tocProvider.getForDocument(document);
-		if (token.isCancellationRequested) {
-			return [];
-		}
-
-		return this._toSymbolTree(document, linkSymbols, toc);
+		tocProvider: MdTableOfContentsProvider,
+		linkProvider: MdLinkProvider,
+		logger: ILogger,
+	) {
+		this.#tocProvider = tocProvider;
+		this.#linkProvider = linkProvider;
+		this.#logger = logger;
 	}
 
-	private _toSymbolTree(document: ITextDocument, linkSymbols: readonly lsp.DocumentSymbol[], toc: TableOfContents): lsp.DocumentSymbol[] {
+	public async provideDocumentSymbols(document: ITextDocument, options: ProvideDocumentSymbolOptions, token: CancellationToken): Promise<lsp.DocumentSymbol[]> {
+		this.#logger.log(LogLevel.Trace, 'DocumentSymbolProvider', `provideDocumentSymbols — ${document.uri} ${document.version}`);
+
+		const linkSymbols = await (options.includeLinkDefinitions ? this.#provideLinkDefinitionSymbols(document, token) : []);
+		if (token.isCancellationRequested) {
+			return [];
+		}
+
+		const toc = await this.#tocProvider.getForDocument(document);
+		if (token.isCancellationRequested) {
+			return [];
+		}
+
+		return this.#toSymbolTree(document, linkSymbols, toc);
+	}
+
+	#toSymbolTree(document: ITextDocument, linkSymbols: readonly lsp.DocumentSymbol[], toc: TableOfContents): lsp.DocumentSymbol[] {
 		const root: MarkdownSymbol = {
 			level: -Infinity,
 			children: [],
@@ -55,24 +63,24 @@ export class MdDocumentSymbolProvider {
 			range: makeRange(0, 0, document.lineCount + 1, 0),
 		};
 		const additionalSymbols = [...linkSymbols];
-		this._buildTocSymbolTree(root, toc.entries, additionalSymbols);
+		this.#buildTocSymbolTree(root, toc.entries, additionalSymbols);
 		// Put remaining link definitions into top level document instead of last header
 		root.children.push(...additionalSymbols);
 		return root.children;
 	}
 
-	private async _provideLinkDefinitionSymbols(document: ITextDocument, token: CancellationToken): Promise<lsp.DocumentSymbol[]> {
-		const { links } = await this._linkProvider.getLinks(document);
+	async #provideLinkDefinitionSymbols(document: ITextDocument, token: CancellationToken): Promise<lsp.DocumentSymbol[]> {
+		const { links } = await this.#linkProvider.getLinks(document);
 		if (token.isCancellationRequested) {
 			return [];
 		}
 
 		return links
 			.filter(link => link.kind === MdLinkKind.Definition)
-			.map((link): lsp.DocumentSymbol => this._definitionToDocumentSymbol(link as MdLinkDefinition));
+			.map((link): lsp.DocumentSymbol => this.#definitionToDocumentSymbol(link as MdLinkDefinition));
 	}
 
-	private _definitionToDocumentSymbol(def: MdLinkDefinition): lsp.DocumentSymbol {
+	#definitionToDocumentSymbol(def: MdLinkDefinition): lsp.DocumentSymbol {
 		return {
 			kind: lsp.SymbolKind.Constant,
 			name: `[${def.ref.text}]`,
@@ -81,7 +89,7 @@ export class MdDocumentSymbolProvider {
 		};
 	}
 
-	private _buildTocSymbolTree(parent: MarkdownSymbol, entries: readonly TocEntry[], additionalSymbols: lsp.DocumentSymbol[]): void {
+	#buildTocSymbolTree(parent: MarkdownSymbol, entries: readonly TocEntry[], additionalSymbols: lsp.DocumentSymbol[]): void {
 		if (entries.length) {
 			while (additionalSymbols.length && isBefore(additionalSymbols[0].range.end, entries[0].sectionLocation.range.start)) {
 				parent.children.push(additionalSymbols.shift()!);
@@ -93,7 +101,7 @@ export class MdDocumentSymbolProvider {
 		}
 
 		const entry = entries[0];
-		const symbol = this._tocToDocumentSymbol(entry);
+		const symbol = this.#tocToDocumentSymbol(entry);
 		symbol.children = [];
 
 		while (entry.level <= parent.level) {
@@ -101,19 +109,19 @@ export class MdDocumentSymbolProvider {
 		}
 		parent.children.push(symbol);
 
-		this._buildTocSymbolTree({ level: entry.level, children: symbol.children, parent, range: entry.sectionLocation.range }, entries.slice(1), additionalSymbols);
+		this.#buildTocSymbolTree({ level: entry.level, children: symbol.children, parent, range: entry.sectionLocation.range }, entries.slice(1), additionalSymbols);
 	}
 
-	private _tocToDocumentSymbol(entry: TocEntry): lsp.DocumentSymbol {
+	#tocToDocumentSymbol(entry: TocEntry): lsp.DocumentSymbol {
 		return {
-			name: this._getTocSymbolName(entry),
+			name: this.#getTocSymbolName(entry),
 			kind: lsp.SymbolKind.String,
 			range: entry.sectionLocation.range,
 			selectionRange: entry.sectionLocation.range
 		};
 	}
 
-	private _getTocSymbolName(entry: TocEntry): string {
+	#getTocSymbolName(entry: TocEntry): string {
 		return '#'.repeat(entry.level) + ' ' + entry.text;
 	}
 }

--- a/src/languageFeatures/organizeLinkDefs.ts
+++ b/src/languageFeatures/organizeLinkDefs.ts
@@ -12,12 +12,14 @@ import { HrefKind, MdLinkDefinition, MdLinkKind, MdLinkProvider } from './docume
 
 export class MdOrganizeLinkDefinitionProvider {
 
-	constructor(
-		private readonly _linkProvider: MdLinkProvider
-	) { }
+	readonly #linkProvider: MdLinkProvider;
+
+	constructor(linkProvider: MdLinkProvider) {
+		this.#linkProvider = linkProvider;
+	}
 
 	async getOrganizeLinkDefinitionEdits(doc: ITextDocument, options: { readonly removeUnused?: boolean }, token: CancellationToken): Promise<lsp.TextEdit[]> {
-		const links = await this._linkProvider.getLinks(doc);
+		const links = await this.#linkProvider.getLinks(doc);
 		if (token.isCancellationRequested) {
 			return [];
 		}
@@ -31,7 +33,7 @@ export class MdOrganizeLinkDefinitionProvider {
 		const edits: lsp.TextEdit[] = [];
 
 		// First replace all inline definitions that are not the definition block
-		for (const group of this._getDefinitionBlockGroups(doc, definitions)) {
+		for (const group of this.#getDefinitionBlockGroups(doc, definitions)) {
 			if (!existingDefBlockRange || group.startLine < existingDefBlockRange.startLine) {
 				// Don't replace trailing newline of last definition in group
 				edits.push({
@@ -74,7 +76,7 @@ export class MdOrganizeLinkDefinitionProvider {
 				range: makeRange(existingDefBlockRange.startLine, 0, existingDefBlockRange.endLine, getLine(doc, existingDefBlockRange.endLine).length)
 			});
 		} else {
-			const line = this._getLastNonWhitespaceLine(doc, definitions);
+			const line = this.#getLastNonWhitespaceLine(doc, definitions);
 			edits.push({
 				newText: (line === doc.lineCount - 1 ? '\n\n' : '\n') + defBlock,
 				range: makeRange(line + 1, 0, doc.lineCount, 0),
@@ -84,7 +86,7 @@ export class MdOrganizeLinkDefinitionProvider {
 		return edits;
 	}
 
-	private *_getDefinitionBlockGroups(doc: ITextDocument, definitions: readonly MdLinkDefinition[]): Iterable<{ readonly startLine: number, readonly endLine: number }> {
+	*#getDefinitionBlockGroups(doc: ITextDocument, definitions: readonly MdLinkDefinition[]): Iterable<{ readonly startLine: number, readonly endLine: number }> {
 		if (!definitions.length) {
 			return;
 		}
@@ -102,10 +104,10 @@ export class MdOrganizeLinkDefinitionProvider {
 		}
 
 		yield { startLine: startDef.source.range.start.line, endLine: endDef.source.range.start.line };
-		yield* this._getDefinitionBlockGroups(doc, definitions.slice(i + 1));
+		yield* this.#getDefinitionBlockGroups(doc, definitions.slice(i + 1));
 	}
 
-	private _getLastNonWhitespaceLine(doc: ITextDocument, orderedDefinitions: readonly MdLinkDefinition[]): number {
+	#getLastNonWhitespaceLine(doc: ITextDocument, orderedDefinitions: readonly MdLinkDefinition[]): number {
 		const lastDef = orderedDefinitions[orderedDefinitions.length - 1];
 		const textAfter = doc.getText(makeRange(lastDef.source.range.end.line + 1, 0, Infinity, 0));
 		const lines = textAfter.split(/\r\n|\n/g);

--- a/src/languageFeatures/references.ts
+++ b/src/languageFeatures/references.ts
@@ -73,15 +73,29 @@ export type MdReference = MdLinkReference | MdHeaderReference;
  */
 export class MdReferencesProvider extends Disposable {
 
+	readonly #configuration: LsConfiguration;
+	readonly #parser: IMdParser;
+	readonly #workspace: IWorkspace;
+	readonly #tocProvider: MdTableOfContentsProvider;
+	readonly #linkCache: MdWorkspaceInfoCache<readonly MdLink[]>;
+	readonly #logger: ILogger;
+
 	public constructor(
-		private readonly _configuration: LsConfiguration,
-		private readonly _parser: IMdParser,
-		private readonly _workspace: IWorkspace,
-		private readonly _tocProvider: MdTableOfContentsProvider,
-		private readonly _linkCache: MdWorkspaceInfoCache<readonly MdLink[]>,
-		private readonly _logger: ILogger,
+		configuration: LsConfiguration,
+		parser: IMdParser,
+		workspace: IWorkspace,
+		tocProvider: MdTableOfContentsProvider,
+		linkCache: MdWorkspaceInfoCache<readonly MdLink[]>,
+		logger: ILogger,
 	) {
 		super();
+
+		this.#configuration = configuration;
+		this.#parser = parser;
+		this.#workspace = workspace;
+		this.#tocProvider = tocProvider;
+		this.#linkCache = linkCache;
+		this.#logger = logger;
 	}
 
 	async provideReferences(document: ITextDocument, position: lsp.Position, context: lsp.ReferenceContext, token: CancellationToken): Promise<lsp.Location[]> {
@@ -92,34 +106,34 @@ export class MdReferencesProvider extends Disposable {
 	}
 
 	public async getReferencesAtPosition(document: ITextDocument, position: lsp.Position, token: CancellationToken): Promise<MdReference[]> {
-		this._logger.log(LogLevel.Trace, 'ReferencesProvider', `getReferencesAtPosition — ${document.uri} ${document.version}`);
+		this.#logger.log(LogLevel.Trace, 'ReferencesProvider', `getReferencesAtPosition — ${document.uri} ${document.version}`);
 
-		const toc = await this._tocProvider.getForDocument(document);
+		const toc = await this.#tocProvider.getForDocument(document);
 		if (token.isCancellationRequested) {
 			return [];
 		}
 
 		const header = toc.entries.find(entry => entry.line === position.line);
 		if (header) {
-			return this._getReferencesToHeader(document, header, token);
+			return this.#getReferencesToHeader(document, header, token);
 		} else {
-			return this._getReferencesToLinkAtPosition(document, position, token);
+			return this.#getReferencesToLinkAtPosition(document, position, token);
 		}
 	}
 
 	public async getReferencesToFileInWorkspace(resource: URI, token: CancellationToken): Promise<MdReference[]> {
-		this._logger.log(LogLevel.Trace, 'ReferencesProvider', `getAllReferencesToFileInWorkspace — ${resource}`);
+		this.#logger.log(LogLevel.Trace, 'ReferencesProvider', `getAllReferencesToFileInWorkspace — ${resource}`);
 
-		const allLinksInWorkspace = await this._getAllLinksInWorkspace();
+		const allLinksInWorkspace = await this.#getAllLinksInWorkspace();
 		if (token.isCancellationRequested) {
 			return [];
 		}
 
-		return Array.from(this._findLinksToFile(resource, allLinksInWorkspace, undefined));
+		return Array.from(this.#findLinksToFile(resource, allLinksInWorkspace, undefined));
 	}
 
-	private async _getReferencesToHeader(document: ITextDocument, header: TocEntry, token: CancellationToken): Promise<MdReference[]> {
-		const links = await this._getAllLinksInWorkspace();
+	async #getReferencesToHeader(document: ITextDocument, header: TocEntry, token: CancellationToken): Promise<MdReference[]> {
+		const links = await this.#getAllLinksInWorkspace();
 		if (token.isCancellationRequested) {
 			return [];
 		}
@@ -137,8 +151,8 @@ export class MdReferencesProvider extends Disposable {
 
 		for (const link of links) {
 			if (link.href.kind === HrefKind.Internal
-				&& looksLikeLinkToResource(this._configuration, link.href, getDocUri(document))
-				&& this._parser.slugifier.fromHeading(link.href.fragment).value === header.slug.value
+				&& looksLikeLinkToResource(this.#configuration, link.href, getDocUri(document))
+				&& this.#parser.slugifier.fromHeading(link.href.fragment).value === header.slug.value
 			) {
 				references.push({
 					kind: MdReferenceKind.Link,
@@ -153,8 +167,8 @@ export class MdReferencesProvider extends Disposable {
 		return references;
 	}
 
-	private async _getReferencesToLinkAtPosition(document: ITextDocument, position: lsp.Position, token: CancellationToken): Promise<MdReference[]> {
-		const docLinks = (await this._linkCache.getForDocs([document]))[0];
+	async #getReferencesToLinkAtPosition(document: ITextDocument, position: lsp.Position, token: CancellationToken): Promise<MdReference[]> {
+		const docLinks = (await this.#linkCache.getForDocs([document]))[0];
 		if (token.isCancellationRequested) {
 			return [];
 		}
@@ -163,13 +177,13 @@ export class MdReferencesProvider extends Disposable {
 			if (link.kind === MdLinkKind.Definition) {
 				// We could be in either the ref name or the definition
 				if (rangeContains(link.ref.range, position)) {
-					return Array.from(this._getReferencesToLinkReference(docLinks, link.ref.text, { resource: getDocUri(document), range: link.ref.range }));
+					return Array.from(this.#getReferencesToLinkReference(docLinks, link.ref.text, { resource: getDocUri(document), range: link.ref.range }));
 				} else if (rangeContains(link.source.hrefRange, position)) {
-					return this._getReferencesToLink(docLinks, link, position, token);
+					return this.#getReferencesToLink(docLinks, link, position, token);
 				}
 			} else {
 				if (rangeContains(link.source.hrefRange, position)) {
-					return this._getReferencesToLink(docLinks, link, position, token);
+					return this.#getReferencesToLink(docLinks, link, position, token);
 				}
 			}
 		}
@@ -177,13 +191,13 @@ export class MdReferencesProvider extends Disposable {
 		return [];
 	}
 
-	private async _getReferencesToLink(docLinks: Iterable<MdLink>, sourceLink: MdLink, triggerPosition: lsp.Position, token: CancellationToken): Promise<MdReference[]> {
+	async #getReferencesToLink(docLinks: Iterable<MdLink>, sourceLink: MdLink, triggerPosition: lsp.Position, token: CancellationToken): Promise<MdReference[]> {
 		if (sourceLink.href.kind === HrefKind.Reference) {
-			return Array.from(this._getReferencesToLinkReference(docLinks, sourceLink.href.ref, { resource: sourceLink.source.resource, range: sourceLink.source.hrefRange }));
+			return Array.from(this.#getReferencesToLinkReference(docLinks, sourceLink.href.ref, { resource: sourceLink.source.resource, range: sourceLink.source.hrefRange }));
 		}
 
 		// Otherwise find all occurrences of the link in the workspace
-		const allLinksInWorkspace = await this._getAllLinksInWorkspace();
+		const allLinksInWorkspace = await this.#getAllLinksInWorkspace();
 		if (token.isCancellationRequested) {
 			return [];
 		}
@@ -206,15 +220,15 @@ export class MdReferencesProvider extends Disposable {
 			return references;
 		}
 
-		const resolvedResource = await statLinkToMarkdownFile(this._configuration, this._workspace, sourceLink.href.path);
+		const resolvedResource = await statLinkToMarkdownFile(this.#configuration, this.#workspace, sourceLink.href.path);
 		if (token.isCancellationRequested) {
 			return [];
 		}
 
 		const references: MdReference[] = [];
 
-		if (resolvedResource && this._isMarkdownPath(resolvedResource) && sourceLink.href.fragment && sourceLink.source.fragmentRange && rangeContains(sourceLink.source.fragmentRange, triggerPosition)) {
-			const toc = await this._tocProvider.get(resolvedResource);
+		if (resolvedResource && this.#isMarkdownPath(resolvedResource) && sourceLink.href.fragment && sourceLink.source.fragmentRange && rangeContains(sourceLink.source.fragmentRange, triggerPosition)) {
+			const toc = await this.#tocProvider.get(resolvedResource);
 			const entry = toc.lookup(sourceLink.href.fragment);
 			if (entry) {
 				references.push({
@@ -228,11 +242,11 @@ export class MdReferencesProvider extends Disposable {
 			}
 
 			for (const link of allLinksInWorkspace) {
-				if (link.href.kind !== HrefKind.Internal || !looksLikeLinkToResource(this._configuration, link.href, resolvedResource)) {
+				if (link.href.kind !== HrefKind.Internal || !looksLikeLinkToResource(this.#configuration, link.href, resolvedResource)) {
 					continue;
 				}
 
-				if (this._parser.slugifier.fromHeading(link.href.fragment).equals(this._parser.slugifier.fromHeading(sourceLink.href.fragment))) {
+				if (this.#parser.slugifier.fromHeading(link.href.fragment).equals(this.#parser.slugifier.fromHeading(sourceLink.href.fragment))) {
 					const isTriggerLocation = sourceLink.source.resource.fsPath === link.source.resource.fsPath && areRangesEqual(sourceLink.source.hrefRange, link.source.hrefRange);
 					references.push({
 						kind: MdReferenceKind.Link,
@@ -244,23 +258,23 @@ export class MdReferencesProvider extends Disposable {
 				}
 			}
 		} else { // Triggered on a link without a fragment so we only require matching the file and ignore fragments
-			references.push(...this._findLinksToFile(resolvedResource ?? sourceLink.href.path, allLinksInWorkspace, sourceLink));
+			references.push(...this.#findLinksToFile(resolvedResource ?? sourceLink.href.path, allLinksInWorkspace, sourceLink));
 		}
 
 		return references;
 	}
 
-	private async _getAllLinksInWorkspace(): Promise<readonly MdLink[]> {
-		return (await this._linkCache.values()).flat();
+	async #getAllLinksInWorkspace(): Promise<readonly MdLink[]> {
+		return (await this.#linkCache.values()).flat();
 	}
 
-	private _isMarkdownPath(resolvedHrefPath: URI) {
-		return this._workspace.hasMarkdownDocument(resolvedHrefPath) || looksLikeMarkdownPath(this._configuration, resolvedHrefPath);
+	#isMarkdownPath(resolvedHrefPath: URI) {
+		return this.#workspace.hasMarkdownDocument(resolvedHrefPath) || looksLikeMarkdownPath(this.#configuration, resolvedHrefPath);
 	}
 
-	private *_findLinksToFile(resource: URI, links: readonly MdLink[], sourceLink: MdLink | undefined): Iterable<MdReference> {
+	*#findLinksToFile(resource: URI, links: readonly MdLink[], sourceLink: MdLink | undefined): Iterable<MdReference> {
 		for (const link of links) {
-			if (link.href.kind !== HrefKind.Internal || !looksLikeLinkToResource(this._configuration, link.href, resource)) {
+			if (link.href.kind !== HrefKind.Internal || !looksLikeLinkToResource(this.#configuration, link.href, resource)) {
 				continue;
 			}
 
@@ -270,7 +284,7 @@ export class MdReferencesProvider extends Disposable {
 			}
 
 			const isTriggerLocation = !!sourceLink && sourceLink.source.resource.fsPath === link.source.resource.fsPath && areRangesEqual(sourceLink.source.hrefRange, link.source.hrefRange);
-			const pathRange = this._getPathRange(link);
+			const pathRange = this.#getPathRange(link);
 			yield {
 				kind: MdReferenceKind.Link,
 				isTriggerLocation,
@@ -281,7 +295,7 @@ export class MdReferencesProvider extends Disposable {
 		}
 	}
 
-	private *_getReferencesToLinkReference(allLinks: Iterable<MdLink>, refToFind: string, from: { resource: URI; range: lsp.Range }): Iterable<MdReference> {
+	*#getReferencesToLinkReference(allLinks: Iterable<MdLink>, refToFind: string, from: { resource: URI; range: lsp.Range }): Iterable<MdReference> {
 		for (const link of allLinks) {
 			let ref: string;
 			if (link.kind === MdLinkKind.Definition) {
@@ -296,7 +310,7 @@ export class MdReferencesProvider extends Disposable {
 				const isTriggerLocation = from.resource.fsPath === link.source.resource.fsPath && (
 					(link.href.kind === HrefKind.Reference && areRangesEqual(from.range, link.source.hrefRange)) || (link.kind === MdLinkKind.Definition && areRangesEqual(from.range, link.ref.range)));
 
-				const pathRange = this._getPathRange(link);
+				const pathRange = this.#getPathRange(link);
 				yield {
 					kind: MdReferenceKind.Link,
 					isTriggerLocation,
@@ -311,7 +325,7 @@ export class MdReferencesProvider extends Disposable {
 	/**
 	 * Get just the range of the file path, dropping the fragment
 	 */
-	private _getPathRange(link: MdLink): lsp.Range {
+	#getPathRange(link: MdLink): lsp.Range {
 		return link.source.fragmentRange
 			? modifyRange(link.source.hrefRange, undefined, translatePosition(link.source.fragmentRange.start, { characterDelta: -1 }))
 			: link.source.hrefRange;

--- a/src/tableOfContents.ts
+++ b/src/tableOfContents.ts
@@ -68,7 +68,7 @@ export interface TocEntry {
 export class TableOfContents {
 
 	public static async create(parser: IMdParser, document: ITextDocument, token: CancellationToken): Promise<TableOfContents> {
-		const entries = await this._buildToc(parser, document, token);
+		const entries = await this.#buildToc(parser, document, token);
 		return new TableOfContents(entries, parser.slugifier);
 	}
 
@@ -80,7 +80,7 @@ export class TableOfContents {
 				if (!doc || token.isCancellationRequested) {
 					return [];
 				}
-				return this._buildToc(parser, doc, token);
+				return this.#buildToc(parser, doc, token);
 			}))).flat();
 			return new TableOfContents(entries, parser.slugifier);
 		}
@@ -88,7 +88,7 @@ export class TableOfContents {
 		return this.create(parser, document, token);
 	}
 
-	private static async _buildToc(parser: IMdParser, document: ITextDocument, token: CancellationToken): Promise<TocEntry[]> {
+	static async #buildToc(parser: IMdParser, document: ITextDocument, token: CancellationToken): Promise<TocEntry[]> {
 		const docUri = getDocUri(document);
 
 		const toc: TocEntry[] = [];
@@ -129,7 +129,7 @@ export class TableOfContents {
 
 			const lineNumber = open.map[0];
 			const line = getLine(document, lineNumber);
-			const bodyText = TableOfContents._getHeaderTitleAsPlainText(body);
+			const bodyText = TableOfContents.#getHeaderTitleAsPlainText(body);
 
 			let slug = parser.slugifier.fromHeading(bodyText);
 			const existingSlugEntry = existingSlugEntries.get(slug.value);
@@ -153,7 +153,7 @@ export class TableOfContents {
 			toc.push({
 				slug,
 				text: line.replace(/^\s*#+\s*(.*?)(\s+#+)?$/, (_, word) => word.trim()),
-				level: TableOfContents._getHeaderLevel(open.markup),
+				level: TableOfContents.#getHeaderLevel(open.markup),
 				line: lineNumber,
 				sectionLocation: headerLocation, // Populated in next steps
 				headerLocation,
@@ -183,7 +183,7 @@ export class TableOfContents {
 		});
 	}
 
-	private static _getHeaderLevel(markup: string): number {
+	static #getHeaderLevel(markup: string): number {
 		if (markup === '=') {
 			return 1;
 		} else if (markup === '-') {
@@ -193,9 +193,9 @@ export class TableOfContents {
 		}
 	}
 
-	private static _tokenToPlainText(token: Token): string {
+	static #tokenToPlainText(token: Token): string {
 		if (token.children) {
-			return token.children.map(TableOfContents._tokenToPlainText).join('');
+			return token.children.map(TableOfContents.#tokenToPlainText).join('');
 		}
 
 		switch (token.type) {
@@ -208,22 +208,26 @@ export class TableOfContents {
 		}
 	}
 
-	private static _getHeaderTitleAsPlainText(headerTitleParts: readonly Token[]): string {
+	static #getHeaderTitleAsPlainText(headerTitleParts: readonly Token[]): string {
 		return headerTitleParts
-			.map(TableOfContents._tokenToPlainText)
+			.map(TableOfContents.#tokenToPlainText)
 			.join('')
 			.trim();
 	}
 
 	public static readonly empty = new TableOfContents([], githubSlugifier);
 
+	readonly #slugifier: ISlugifier;
+
 	private constructor(
 		public readonly entries: readonly TocEntry[],
-		private readonly _slugifier: ISlugifier,
-	) { }
+		slugifier: ISlugifier,
+	) {
+		this.#slugifier = slugifier;
+	}
 
 	public lookup(fragment: string): TocEntry | undefined {
-		const slug = this._slugifier.fromHeading(fragment);
+		const slug = this.#slugifier.fromHeading(fragment);
 		return this.entries.find(entry => entry.slug.equals(slug));
 	}
 }
@@ -231,29 +235,38 @@ export class TableOfContents {
 
 export class MdTableOfContentsProvider extends Disposable {
 
-	private readonly _cache: MdDocumentInfoCache<TableOfContents>;
+	readonly #cache: MdDocumentInfoCache<TableOfContents>;
+
+	readonly #parser: IMdParser;
+	readonly #workspace: IWorkspace;
+	readonly #logger: ILogger;
 
 	constructor(
-		private readonly _parser: IMdParser,
-		private readonly _workspace: IWorkspace,
-		private readonly _logger: ILogger,
+		parser: IMdParser,
+		workspace: IWorkspace,
+		logger: ILogger,
 	) {
 		super();
-		this._cache = this._register(new MdDocumentInfoCache<TableOfContents>(_workspace, (doc, token) => {
-			this._logger.log(LogLevel.Debug, 'TableOfContentsProvider', `create - ${doc.uri}`);
-			return TableOfContents.create(_parser, doc, token);
+
+		this.#parser = parser;
+		this.#workspace = workspace;
+		this.#logger = logger;
+
+		this.#cache = this._register(new MdDocumentInfoCache<TableOfContents>(workspace, (doc, token) => {
+			this.#logger.log(LogLevel.Debug, 'TableOfContentsProvider', `create - ${doc.uri}`);
+			return TableOfContents.create(parser, doc, token);
 		}));
 	}
 
 	public async get(resource: URI): Promise<TableOfContents> {
-		return await this._cache.get(resource) ?? TableOfContents.empty;
+		return await this.#cache.get(resource) ?? TableOfContents.empty;
 	}
 
 	public getForDocument(doc: ITextDocument): Promise<TableOfContents> {
-		return this._cache.getForDocument(doc);
+		return this.#cache.getForDocument(doc);
 	}
 
 	public getForContainingDoc(doc: ITextDocument, token: CancellationToken): Promise<TableOfContents> {
-		return TableOfContents.createForContainingDoc(this._parser, this._workspace, doc, token);
+		return TableOfContents.createForContainingDoc(this.#parser, this.#workspace, doc, token);
 	}
 }

--- a/src/test/inMemoryDocument.ts
+++ b/src/test/inMemoryDocument.ts
@@ -10,7 +10,7 @@ import { ITextDocument } from '../types/textDocument';
 
 export class InMemoryDocument implements ITextDocument {
 
-	private _doc: TextDocument;
+	#doc: TextDocument;
 
 	public readonly $uri: URI;
 	public readonly uri: string;
@@ -23,27 +23,27 @@ export class InMemoryDocument implements ITextDocument {
 		this.$uri = uri;
 		this.uri = uri.toString();
 
-		this._doc = TextDocument.create(this.uri, 'markdown', version, contents);
+		this.#doc = TextDocument.create(this.uri, 'markdown', version, contents);
 	}
 
 	get lineCount(): number {
-		return this._doc.lineCount;
+		return this.#doc.lineCount;
 	}
 
 	positionAt(offset: number): lsp.Position {
-		return this._doc.positionAt(offset);
+		return this.#doc.positionAt(offset);
 	}
 
 	getText(range?: lsp.Range): string {
-		return this._doc.getText(range);
+		return this.#doc.getText(range);
 	}
 
 	updateContent(newContent: string) {
 		++this.version;
-		this._doc = TextDocument.create(this.uri, 'markdown', this.version, newContent);
+		this.#doc = TextDocument.create(this.uri, 'markdown', this.version, newContent);
 	}
 
 	applyEdits(textEdits: lsp.TextEdit[]): string {
-		return TextDocument.applyEdits(this._doc, textEdits);
+		return TextDocument.applyEdits(this.#doc, textEdits);
 	}
 }

--- a/src/util/cancellation.ts
+++ b/src/util/cancellation.ts
@@ -6,8 +6,8 @@
 import { CancellationToken, Emitter } from 'vscode-languageserver';
 
 export const noopToken: CancellationToken = new class implements CancellationToken {
-	private readonly _onCancellationRequestedEmitter = new Emitter<void>();
-	onCancellationRequested = this._onCancellationRequestedEmitter.event;
+	readonly #onCancellationRequestedEmitter = new Emitter<void>();
+	onCancellationRequested = this.#onCancellationRequestedEmitter.event;
 
 	get isCancellationRequested() { return false; }
 }();

--- a/src/util/dispose.ts
+++ b/src/util/dispose.ts
@@ -38,20 +38,20 @@ export interface IDisposable {
 }
 
 export abstract class Disposable {
-	private _isDisposed = false;
+	#isDisposed = false;
 
 	protected _disposables: IDisposable[] = [];
 
 	public dispose(): any {
-		if (this._isDisposed) {
+		if (this.#isDisposed) {
 			return;
 		}
-		this._isDisposed = true;
+		this.#isDisposed = true;
 		disposeAll(this._disposables);
 	}
 
 	protected _register<T extends IDisposable>(value: T): T {
-		if (this._isDisposed) {
+		if (this.#isDisposed) {
 			value.dispose();
 		} else {
 			this._disposables.push(value);
@@ -60,17 +60,17 @@ export abstract class Disposable {
 	}
 
 	protected get isDisposed() {
-		return this._isDisposed;
+		return this.#isDisposed;
 	}
 }
 
 export class DisposableStore extends Disposable {
-	private readonly _items = new Set<IDisposable>();
+	readonly #items = new Set<IDisposable>();
 
 	public override dispose() {
 		super.dispose();
-		disposeAll(this._items);
-		this._items.clear();
+		disposeAll(this.#items);
+		this.#items.clear();
 	}
 
 	public add<T extends IDisposable>(item: T): T {
@@ -78,7 +78,7 @@ export class DisposableStore extends Disposable {
 			console.warn('Adding to disposed store. Item will be leaked');
 		}
 
-		this._items.add(item);
+		this.#items.add(item);
 		return item;
 	}
 }

--- a/src/util/editBuilder.ts
+++ b/src/util/editBuilder.ts
@@ -8,23 +8,23 @@ import { URI } from 'vscode-uri';
 
 export class WorkspaceEditBuilder {
 
-	private readonly _changes: { [uri: lsp.DocumentUri]: lsp.TextEdit[]; } = {};
-	private readonly _documentChanges: Array<lsp.CreateFile | lsp.RenameFile | lsp.DeleteFile> = [];
+	readonly #changes: { [uri: lsp.DocumentUri]: lsp.TextEdit[]; } = {};
+	readonly #documentChanges: Array<lsp.CreateFile | lsp.RenameFile | lsp.DeleteFile> = [];
 
 	replace(resource: URI, range: lsp.Range, newText: string): void {
-		this._addEdit(resource, lsp.TextEdit.replace(range, newText));
+		this.#addEdit(resource, lsp.TextEdit.replace(range, newText));
 	}
 
 	insert(resource: URI, position: lsp.Position, newText: string): void {
-		this._addEdit(resource, lsp.TextEdit.insert(position, newText));
+		this.#addEdit(resource, lsp.TextEdit.insert(position, newText));
 	}
 
-	private _addEdit(resource: URI, edit: lsp.TextEdit): void {
+	#addEdit(resource: URI, edit: lsp.TextEdit): void {
 		const resourceKey = resource.toString();
-		let edits = this._changes![resourceKey];
+		let edits = this.#changes![resourceKey];
 		if (!edits) {
 			edits = [];
-			this._changes![resourceKey] = edits;
+			this.#changes![resourceKey] = edits;
 		}
 
 		edits.push(edit);
@@ -32,16 +32,16 @@ export class WorkspaceEditBuilder {
 
 	renameFragment(): lsp.WorkspaceEdit {
 		// We need to convert changes into `documentChanges` or else they get dropped
-		const textualChanges = Object.entries(this._changes).map(([uri, edits]): lsp.TextDocumentEdit => {
+		const textualChanges = Object.entries(this.#changes).map(([uri, edits]): lsp.TextDocumentEdit => {
 			return lsp.TextDocumentEdit.create({ uri, version: null }, edits);
 		});
 
 		return {
-			documentChanges: [...textualChanges, ...this._documentChanges],
+			documentChanges: [...textualChanges, ...this.#documentChanges],
 		};
 	}
 
 	renameFile(targetUri: URI, resolvedNewFilePath: URI) {
-		this._documentChanges.push(lsp.RenameFile.create(targetUri.toString(), resolvedNewFilePath.toString()));
+		this.#documentChanges.push(lsp.RenameFile.create(targetUri.toString(), resolvedNewFilePath.toString()));
 	}
 }

--- a/src/util/lazy.ts
+++ b/src/util/lazy.ts
@@ -10,23 +10,25 @@ export interface Lazy<T> {
 }
 
 class LazyValue<T> implements Lazy<T> {
-	private _hasValue = false;
-	private _value?: T;
+	#hasValue = false;
+	#value?: T;
 
-	constructor(
-		private readonly _getValue: () => T
-	) { }
+	readonly #getValue: () => T;
+
+	constructor(getValue: () => T) {
+		this.#getValue = getValue;
+	}
 
 	get value(): T {
-		if (!this._hasValue) {
-			this._hasValue = true;
-			this._value = this._getValue();
+		if (!this.#hasValue) {
+			this.#hasValue = true;
+			this.#value = this.#getValue();
 		}
-		return this._value!;
+		return this.#value!;
 	}
 
 	get hasValue(): boolean {
-		return this._hasValue;
+		return this.#hasValue;
 	}
 
 	public map<R>(f: (x: T) => R): Lazy<R> {

--- a/src/util/limiter.ts
+++ b/src/util/limiter.ts
@@ -21,47 +21,47 @@ interface ITask<T> {
  */
 export class Limiter<T> {
 
-	private _size = 0;
-	private _runningPromises: number;
-	private readonly _maxDegreeOfParalellism: number;
-	private readonly _outstandingPromises: ILimitedTaskFactory<T>[];
+	#size = 0;
+	#runningPromises: number;
+	readonly #maxDegreeOfParalellism: number;
+	readonly #outstandingPromises: ILimitedTaskFactory<T>[];
 
 	constructor(maxDegreeOfParalellism: number) {
-		this._maxDegreeOfParalellism = maxDegreeOfParalellism;
-		this._outstandingPromises = [];
-		this._runningPromises = 0;
+		this.#maxDegreeOfParalellism = maxDegreeOfParalellism;
+		this.#outstandingPromises = [];
+		this.#runningPromises = 0;
 	}
 
 	get size(): number {
-		return this._size;
+		return this.#size;
 	}
 
 	queue(factory: ITask<Promise<T>>): Promise<T> {
-		this._size++;
+		this.#size++;
 
 		return new Promise<T>((c, e) => {
-			this._outstandingPromises.push({ factory, c, e });
-			this._consume();
+			this.#outstandingPromises.push({ factory, c, e });
+			this.#consume();
 		});
 	}
 
-	private _consume(): void {
-		while (this._outstandingPromises.length && this._runningPromises < this._maxDegreeOfParalellism) {
-			const iLimitedTask = this._outstandingPromises.shift()!;
-			this._runningPromises++;
+	#consume(): void {
+		while (this.#outstandingPromises.length && this.#runningPromises < this.#maxDegreeOfParalellism) {
+			const iLimitedTask = this.#outstandingPromises.shift()!;
+			this.#runningPromises++;
 
 			const promise = iLimitedTask.factory();
 			promise.then(iLimitedTask.c, iLimitedTask.e);
-			promise.then(() => this._consumed(), () => this._consumed());
+			promise.then(() => this.#consumed(), () => this.#consumed());
 		}
 	}
 
-	private _consumed(): void {
-		this._size--;
-		this._runningPromises--;
+	#consumed(): void {
+		this.#size--;
+		this.#runningPromises--;
 
-		if (this._outstandingPromises.length > 0) {
-			this._consume();
+		if (this.#outstandingPromises.length > 0) {
+			this.#consume();
 		}
 	}
 }

--- a/src/util/resourceMap.ts
+++ b/src/util/resourceMap.ts
@@ -12,53 +12,53 @@ const defaultResourceToKey = (resource: URI): string => resource.toString();
 
 export class ResourceMap<T> {
 
-	private readonly _map = new Map<string, { readonly uri: URI; readonly value: T }>();
+	readonly #map = new Map<string, { readonly uri: URI; readonly value: T }>();
 
-	private readonly _toKey: ResourceToKey;
+	readonly #toKey: ResourceToKey;
 
 	constructor(toKey: ResourceToKey = defaultResourceToKey) {
-		this._toKey = toKey;
+		this.#toKey = toKey;
 	}
 
 	public set(uri: URI, value: T): this {
-		this._map.set(this._toKey(uri), { uri, value });
+		this.#map.set(this.#toKey(uri), { uri, value });
 		return this;
 	}
 
 	public get(resource: URI): T | undefined {
-		return this._map.get(this._toKey(resource))?.value;
+		return this.#map.get(this.#toKey(resource))?.value;
 	}
 
 	public has(resource: URI): boolean {
-		return this._map.has(this._toKey(resource));
+		return this.#map.has(this.#toKey(resource));
 	}
 
 	public get size(): number {
-		return this._map.size;
+		return this.#map.size;
 	}
 
 	public clear(): void {
-		this._map.clear();
+		this.#map.clear();
 	}
 
 	public delete(resource: URI): boolean {
-		return this._map.delete(this._toKey(resource));
+		return this.#map.delete(this.#toKey(resource));
 	}
 
 	public *values(): IterableIterator<T> {
-		for (const entry of this._map.values()) {
+		for (const entry of this.#map.values()) {
 			yield entry.value;
 		}
 	}
 
 	public *keys(): IterableIterator<URI> {
-		for (const entry of this._map.values()) {
+		for (const entry of this.#map.values()) {
 			yield entry.uri;
 		}
 	}
 
 	public *entries(): IterableIterator<[URI, T]> {
-		for (const entry of this._map.values()) {
+		for (const entry of this.#map.values()) {
 			yield [entry.uri, entry.value];
 		}
 	}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-		"target": "es2020",
+		"target": "es2022",
 		"lib": [
 			"ES2020",
 		],


### PR DESCRIPTION
This switches us to use runtime privates instead of the `private` keyword. The main benefit is that lets us easily mangle private names