### PR TITLE
0.3.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.3.0-alpha.2 UNRELEASED
+## 0.3.0-alpha.2 November 14, 2022
 - Switch to `@vscode/l10n` for localization.
 
 ## 0.3.0-alpha.1 November 4, 2022

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-markdown-languageservice",
-  "version": "0.3.0-alpha.1",
+  "version": "0.3.0-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-markdown-languageservice",
-      "version": "0.3.0-alpha.1",
+      "version": "0.3.0-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@vscode/l10n": "^0.0.10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-markdown-languageservice",
   "description": "Markdown language service",
-  "version": "0.3.0-alpha.1",
+  "version": "0.3.0-alpha.2",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Bumping version to use `@vscode/l10n`