### PR TITLE
Explicitly run `api-extractor` as part of pre-publish step

### DIFF
--- a/build/pipeline.yml
+++ b/build/pipeline.yml
@@ -32,6 +32,9 @@ extends:
 
           - script: npm run compile
             displayName: Compile
+            
+          - script: npm run api-extractor
+            displayName: API Extractor
 
         testPlatforms:
           - name: Linux


### PR DESCRIPTION
For #101 