### PR TITLE
Make sure api-extractor output dir exists

### DIFF
--- a/api-extractor.json
+++ b/api-extractor.json
@@ -95,29 +95,7 @@
      * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
      * DEFAULT VALUE: "<projectFolder>/tsconfig.json"
      */
-    // "tsconfigFilePath": "<projectFolder>/tsconfig.json",
-    /**
-     * Provides a compiler configuration that will be used instead of reading the tsconfig.json file from disk.
-     * The object must conform to the TypeScript tsconfig schema:
-     *
-     * http://json.schemastore.org/tsconfig
-     *
-     * If omitted, then the tsconfig.json file will be read from the "projectFolder".
-     *
-     * DEFAULT VALUE: no overrideTsconfig section
-     */
-    // "overrideTsconfig": {
-    //   . . .
-    // }
-    /**
-     * This option causes the compiler to be invoked with the --skipLibCheck option. This option is not recommended
-     * and may cause API Extractor to produce incomplete or incorrect declarations, but it may be required when
-     * dependencies contain declarations that are incompatible with the TypeScript engine that API Extractor uses
-     * for its analysis.  Where possible, the underlying issue should be fixed rather than relying on skipLibCheck.
-     *
-     * DEFAULT VALUE: false
-     */
-    // "skipLibCheck": true,
+    "tsconfigFilePath": "tsconfig.lib.json"
   },
   /**
    * Configures how the API report file (*.api.md) will be generated.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-markdown-languageservice",
-  "version": "0.3.0-alpha.2",
+  "version": "0.3.0-alpha.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-markdown-languageservice",
-      "version": "0.3.0-alpha.2",
+      "version": "0.3.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "@vscode/l10n": "^0.0.10",
@@ -25,6 +25,7 @@
         "@typescript-eslint/parser": "^5.30.5",
         "eslint": "^8.19.0",
         "markdown-it": "^13.0.1",
+        "mkdirp": "^1.0.4",
         "mocha": "^10.0.0",
         "typescript": "^4.7.4",
         "vscode-languageserver": "^8.0.1"
@@ -1767,6 +1768,18 @@
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       },
       "engines": {
         "node": ">=10"
@@ -3904,6 +3917,12 @@
       "requires": {
         "brace-expansion": "^2.0.1"
       }
+    },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true
     },
     "mocha": {
       "version": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -31,12 +31,13 @@
     "@typescript-eslint/parser": "^5.30.5",
     "eslint": "^8.19.0",
     "markdown-it": "^13.0.1",
+    "mkdirp": "^1.0.4",
     "mocha": "^10.0.0",
     "typescript": "^4.7.4",
     "vscode-languageserver": "^8.0.1"
   },
   "scripts": {
-    "api-extractor": "npx api-extractor run --local",
+    "api-extractor": "mkdirp etc && npx api-extractor run --local",
     "compile": "tsc -b tsconfig.json",
     "watch": "tsc -b tsconfig.json --watch",
     "lint": "eslint \"src/**/*.ts\"",


### PR DESCRIPTION
API extract does not auto create the directories it needs. This causes our release pipeline to fail

Also fixes api extractor running using the wrong tsconfig, which was generating a lot of warnings 