### PR TITLE
Fix linting of generated d.ts and json files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,4 +23,7 @@ module.exports = {
 			},
 		],
 	},
+	ignorePatterns: [
+		'types/**/*.d.ts'
+	]
 }; 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,9 @@
 		"main"
 	],
 	"git.branchProtectionPrompt": "alwaysCommitToNewBranch",
-	"typescript.preferences.quoteStyle": "single"
+	"typescript.preferences.quoteStyle": "single",
+	"files.associations": {
+		"api-extractor.json": "jsonc",
+		"tsdoc-metadata.json": "jsonc"
+	}
 }


### PR DESCRIPTION
- Disables linting of the generated `d.ts` file when opened in an editor
- Makes VS Code treat api-extractor json files as `jsonc`