### PR TITLE
Expose IMdLinkComputer for custom link computers

### DIFF
--- a/src/test/codeActions/extractLinkDef.test.ts
+++ b/src/test/codeActions/extractLinkDef.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as assert from 'assert';
 import * as lsp from 'vscode-languageserver-types';
-import { MdLinkProvider } from '../../languageFeatures/documentLinks';
+import { MdLinkComputer, MdLinkProvider } from '../../languageFeatures/documentLinks';
 import { MdExtractLinkDefinitionCodeActionProvider } from '../../languageFeatures/codeActions/extractLinkDef';
 import { MdTableOfContentsProvider } from '../../tableOfContents';
 import { noopToken } from '../../util/cancellation';
@@ -23,7 +23,8 @@ async function getActions(store: DisposableStore, doc: InMemoryDocument, pos: ls
 	const config = getLsConfiguration({});
 
 	const tocProvider = store.add(new MdTableOfContentsProvider(engine, workspace, nulLogger));
-	const linkProvider = store.add(new MdLinkProvider(config, engine, workspace, tocProvider, nulLogger));
+	const linkComputer = new MdLinkComputer(engine, workspace);
+	const linkProvider = store.add(new MdLinkProvider(config, workspace, linkComputer, tocProvider, nulLogger));
 	const provider = new MdExtractLinkDefinitionCodeActionProvider(linkProvider);
 	return provider.getActions(doc, makeRange(pos, pos), lsp.CodeActionContext.create([], undefined, undefined), noopToken);
 }

--- a/src/test/codeActions/removeLinkDefinition.test.ts
+++ b/src/test/codeActions/removeLinkDefinition.test.ts
@@ -7,7 +7,7 @@ import * as lsp from 'vscode-languageserver-types';
 import { getLsConfiguration } from '../../config';
 import { MdRemoveLinkDefinitionCodeActionProvider } from '../../languageFeatures/codeActions/removeLinkDefinition';
 import { DiagnosticComputer } from '../../languageFeatures/diagnostics';
-import { MdLinkProvider } from '../../languageFeatures/documentLinks';
+import { MdLinkComputer, MdLinkProvider } from '../../languageFeatures/documentLinks';
 import { MdTableOfContentsProvider } from '../../tableOfContents';
 import { makeRange } from '../../types/range';
 import { noopToken } from '../../util/cancellation';
@@ -24,7 +24,8 @@ async function getActions(store: DisposableStore, doc: InMemoryDocument, pos: ls
 	const config = getLsConfiguration({});
 
 	const tocProvider = store.add(new MdTableOfContentsProvider(engine, workspace, nulLogger));
-	const linkProvider = store.add(new MdLinkProvider(config, engine, workspace, tocProvider, nulLogger));
+	const linkComputer = new MdLinkComputer(engine, workspace);
+	const linkProvider = store.add(new MdLinkProvider(config, workspace, linkComputer, tocProvider, nulLogger));
 	const computer = new DiagnosticComputer(config, workspace, linkProvider, tocProvider);
 
 	const provider = new MdRemoveLinkDefinitionCodeActionProvider();

--- a/src/test/definition.test.ts
+++ b/src/test/definition.test.ts
@@ -8,7 +8,7 @@ import * as lsp from 'vscode-languageserver-types';
 import { URI } from 'vscode-uri';
 import { getLsConfiguration } from '../config';
 import { MdDefinitionProvider } from '../languageFeatures/definitions';
-import { createWorkspaceLinkCache } from '../languageFeatures/documentLinks';
+import { createWorkspaceLinkCache, MdLinkComputer } from '../languageFeatures/documentLinks';
 import { MdTableOfContentsProvider } from '../tableOfContents';
 import { noopToken } from '../util/cancellation';
 import { DisposableStore } from '../util/dispose';
@@ -23,7 +23,8 @@ import { joinLines, withStore, workspacePath } from './util';
 function getDefinition(store: DisposableStore, doc: InMemoryDocument, pos: lsp.Position, workspace: IWorkspace) {
 	const engine = createNewMarkdownEngine();
 	const tocProvider = store.add(new MdTableOfContentsProvider(engine, workspace, nulLogger));
-	const linkCache = store.add(createWorkspaceLinkCache(engine, workspace));
+	const linkComputer = new MdLinkComputer(engine, workspace);
+	const linkCache = store.add(createWorkspaceLinkCache(workspace, linkComputer));
 	const provider = new MdDefinitionProvider(getLsConfiguration({}), workspace, tocProvider, linkCache);
 	return provider.provideDefinition(doc, pos, noopToken);
 }

--- a/src/test/diagnostic.test.ts
+++ b/src/test/diagnostic.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import * as lsp from 'vscode-languageserver-types';
 import { getLsConfiguration } from '../config';
 import { DiagnosticComputer, DiagnosticLevel, DiagnosticOptions, DiagnosticsManager } from '../languageFeatures/diagnostics';
-import { MdLinkProvider } from '../languageFeatures/documentLinks';
+import { MdLinkComputer, MdLinkProvider } from '../languageFeatures/documentLinks';
 import { MdTableOfContentsProvider } from '../tableOfContents';
 import { comparePosition } from '../types/position';
 import { makeRange } from '../types/range';
@@ -25,7 +25,8 @@ async function getComputedDiagnostics(store: DisposableStore, doc: InMemoryDocum
 	const engine = createNewMarkdownEngine();
 	const config = getLsConfiguration({});
 	const tocProvider = store.add(new MdTableOfContentsProvider(engine, workspace, nulLogger));
-	const linkProvider = store.add(new MdLinkProvider(config, engine, workspace, tocProvider, nulLogger));
+	const linkComputer = new MdLinkComputer(engine, workspace);
+	const linkProvider = store.add(new MdLinkProvider(config, workspace, linkComputer, tocProvider, nulLogger));
 	const computer = new DiagnosticComputer(config, workspace, linkProvider, tocProvider);
 	return (
 		await computer.compute(doc, getDiagnosticsOptions(options), noopToken)
@@ -446,7 +447,8 @@ suite('Diagnostic Manager', () => {
 		const engine = createNewMarkdownEngine();
 		const config = getLsConfiguration({});
 		const tocProvider = store.add(new MdTableOfContentsProvider(engine, workspace, nulLogger));
-		const linkProvider = store.add(new MdLinkProvider(config, engine, workspace, tocProvider, nulLogger));
+		const linkComputer = new MdLinkComputer(engine, workspace);
+		const linkProvider = store.add(new MdLinkProvider(config, workspace, linkComputer, tocProvider, nulLogger));
 		return store.add(new DiagnosticsManager(config, workspace, linkProvider, tocProvider));
 	}
 

--- a/src/test/documentHighlights.test.ts
+++ b/src/test/documentHighlights.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import * as lsp from 'vscode-languageserver-types';
 import { getLsConfiguration } from '../config';
 import { MdDocumentHighlightProvider } from '../languageFeatures/documentHighlights';
-import { MdLinkProvider } from '../languageFeatures/documentLinks';
+import { MdLinkComputer, MdLinkProvider } from '../languageFeatures/documentLinks';
 import { MdTableOfContentsProvider } from '../tableOfContents';
 import { makeRange } from '../types/range';
 import { noopToken } from '../util/cancellation';
@@ -24,7 +24,8 @@ function getDocumentHighlights(store: DisposableStore, doc: InMemoryDocument, po
 	const engine = createNewMarkdownEngine();
 	const tocProvider = store.add(new MdTableOfContentsProvider(engine, workspace, nulLogger));
 	const config = getLsConfiguration({});
-	const linkProvider = store.add(new MdLinkProvider(config, engine, workspace, tocProvider, nulLogger));
+	const linkComputer = new MdLinkComputer(engine, workspace);
+	const linkProvider = store.add(new MdLinkProvider(config, workspace, linkComputer, tocProvider, nulLogger));
 	const provider = new MdDocumentHighlightProvider(config, tocProvider, linkProvider);
 	return provider.getDocumentHighlights(doc, pos, noopToken);
 }

--- a/src/test/documentSymbols.test.ts
+++ b/src/test/documentSymbols.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import * as lsp from 'vscode-languageserver-types';
 import { getLsConfiguration } from '../config';
-import { MdLinkProvider } from '../languageFeatures/documentLinks';
+import { MdLinkComputer, MdLinkProvider } from '../languageFeatures/documentLinks';
 import { MdDocumentSymbolProvider, ProvideDocumentSymbolOptions } from '../languageFeatures/documentSymbols';
 import { MdTableOfContentsProvider } from '../tableOfContents';
 import { makeRange } from '../types/range';
@@ -26,7 +26,9 @@ function getSymbolsForFile(store: DisposableStore, fileContents: string, options
 	const config = getLsConfiguration({});
 
 	const tocProvider = store.add(new MdTableOfContentsProvider(engine, workspace, nulLogger));
-	const linkProvider = store.add(new MdLinkProvider(config, engine, workspace, tocProvider, nulLogger));
+
+	const linkComputer = new MdLinkComputer(engine, workspace);
+	const linkProvider = store.add(new MdLinkProvider(config, workspace, linkComputer, tocProvider, nulLogger));
 	const provider = new MdDocumentSymbolProvider(tocProvider, linkProvider, nulLogger);
 	return provider.provideDocumentSymbols(doc, options, noopToken);
 }

--- a/src/test/fileReferences.test.ts
+++ b/src/test/fileReferences.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import { URI } from 'vscode-uri';
 import { getLsConfiguration } from '../config';
-import { createWorkspaceLinkCache } from '../languageFeatures/documentLinks';
+import { createWorkspaceLinkCache, MdLinkComputer } from '../languageFeatures/documentLinks';
 import { MdReference, MdReferencesProvider } from '../languageFeatures/references';
 import { MdTableOfContentsProvider } from '../tableOfContents';
 import { noopToken } from '../util/cancellation';
@@ -22,7 +22,8 @@ import { joinLines, withStore, workspacePath } from './util';
 function getFileReferences(store: DisposableStore, resource: URI, workspace: IWorkspace) {
 	const engine = createNewMarkdownEngine();
 	const tocProvider = store.add(new MdTableOfContentsProvider(engine, workspace, nulLogger));
-	const linkCache = store.add(createWorkspaceLinkCache(engine, workspace));
+	const linkComputer = new MdLinkComputer(engine, workspace);
+	const linkCache = store.add(createWorkspaceLinkCache(workspace, linkComputer));
 	const computer = store.add(new MdReferencesProvider(getLsConfiguration({}), engine, workspace, tocProvider, linkCache, nulLogger));
 	return computer.getReferencesToFileInWorkspace(resource, noopToken);
 }

--- a/src/test/fileRename.test.ts
+++ b/src/test/fileRename.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import * as lsp from 'vscode-languageserver-types';
 import { URI } from 'vscode-uri';
 import { getLsConfiguration } from '../config';
-import { createWorkspaceLinkCache } from '../languageFeatures/documentLinks';
+import { createWorkspaceLinkCache, MdLinkComputer } from '../languageFeatures/documentLinks';
 import { FileRenameResponse, MdFileRenameProvider } from '../languageFeatures/fileRename';
 import { MdReferencesProvider } from '../languageFeatures/references';
 import { MdTableOfContentsProvider } from '../tableOfContents';
@@ -28,7 +28,8 @@ function getFileRenameEdits(store: DisposableStore, edits: ReadonlyArray<{ oldUr
 	const config = getLsConfiguration({});
 	const engine = createNewMarkdownEngine();
 	const tocProvider = store.add(new MdTableOfContentsProvider(engine, workspace, nulLogger));
-	const linkCache = store.add(createWorkspaceLinkCache(engine, workspace));
+	const linkComputer = new MdLinkComputer(engine, workspace);
+	const linkCache = store.add(createWorkspaceLinkCache(workspace, linkComputer));
 	const referencesProvider = store.add(new MdReferencesProvider(config, engine, workspace, tocProvider, linkCache, nulLogger));
 	const renameProvider = store.add(new MdFileRenameProvider(getLsConfiguration({}), workspace, linkCache, referencesProvider));
 	return renameProvider.getRenameFilesInWorkspaceEdit(edits, noopToken);

--- a/src/test/organizeLinkDef.test.ts
+++ b/src/test/organizeLinkDef.test.ts
@@ -5,7 +5,7 @@
 import * as assert from 'assert';
 import * as lsp from 'vscode-languageserver-types';
 import { getLsConfiguration } from '../config';
-import { MdLinkProvider } from '../languageFeatures/documentLinks';
+import { MdLinkComputer, MdLinkProvider } from '../languageFeatures/documentLinks';
 import { MdOrganizeLinkDefinitionProvider } from '../languageFeatures/organizeLinkDefs';
 import { MdTableOfContentsProvider } from '../tableOfContents';
 import { noopToken } from '../util/cancellation';
@@ -22,7 +22,8 @@ async function getOrganizeEdits(store: DisposableStore, doc: InMemoryDocument, r
 	const config = getLsConfiguration({});
 
 	const tocProvider = store.add(new MdTableOfContentsProvider(engine, workspace, nulLogger));
-	const linkProvider = store.add(new MdLinkProvider(config, engine, workspace, tocProvider, nulLogger));
+	const linkComputer = new MdLinkComputer(engine, workspace);
+	const linkProvider = store.add(new MdLinkProvider(config, workspace, linkComputer, tocProvider, nulLogger));
 	const organizer = new MdOrganizeLinkDefinitionProvider(linkProvider);
 	return organizer.getOrganizeLinkDefinitionEdits(doc, { removeUnused }, noopToken);
 }

--- a/src/test/pathCompletion.test.ts
+++ b/src/test/pathCompletion.test.ts
@@ -8,7 +8,7 @@ import * as ls from 'vscode-languageserver';
 import * as lsp from 'vscode-languageserver-types';
 import { URI } from 'vscode-uri';
 import { getLsConfiguration, LsConfiguration } from '../config';
-import { MdLinkProvider } from '../languageFeatures/documentLinks';
+import { MdLinkComputer, MdLinkProvider } from '../languageFeatures/documentLinks';
 import { MdPathCompletionProvider } from '../languageFeatures/pathCompletions';
 import { MdTableOfContentsProvider } from '../tableOfContents';
 import { noopToken } from '../util/cancellation';
@@ -28,7 +28,8 @@ async function getCompletionsAtCursor(store: DisposableStore, resource: URI, fil
 	const engine = createNewMarkdownEngine();
 	const ws = workspace ?? store.add(new InMemoryWorkspace([doc]));
 	const tocProvider = store.add(new MdTableOfContentsProvider(engine, ws, nulLogger));
-	const linkProvider = store.add(new MdLinkProvider(config, engine, ws, tocProvider, nulLogger));
+	const linkComputer = new MdLinkComputer(engine, ws);
+	const linkProvider = store.add(new MdLinkProvider(config, ws, linkComputer, tocProvider, nulLogger));
 	const provider = new MdPathCompletionProvider(config, ws, engine, linkProvider);
 	const cursorPositions = getCursorPositions(fileContents, doc);
 	const completions = await provider.provideCompletionItems(doc, cursorPositions[0], {

--- a/src/test/references.test.ts
+++ b/src/test/references.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import * as lsp from 'vscode-languageserver-types';
 import { URI } from 'vscode-uri';
 import { getLsConfiguration } from '../config';
-import { createWorkspaceLinkCache } from '../languageFeatures/documentLinks';
+import { createWorkspaceLinkCache, MdLinkComputer } from '../languageFeatures/documentLinks';
 import { MdReferencesProvider } from '../languageFeatures/references';
 import { MdTableOfContentsProvider } from '../tableOfContents';
 import { comparePosition } from '../types/position';
@@ -24,7 +24,8 @@ import { joinLines, withStore, workspacePath, workspaceRoot } from './util';
 async function getReferences(store: DisposableStore, doc: InMemoryDocument, pos: lsp.Position, workspace: IWorkspace) {
 	const engine = createNewMarkdownEngine();
 	const tocProvider = store.add(new MdTableOfContentsProvider(engine, workspace, nulLogger));
-	const linkCache = store.add(createWorkspaceLinkCache(engine, workspace));
+	const linkComputer = new MdLinkComputer(engine, workspace);
+	const linkCache = store.add(createWorkspaceLinkCache(workspace, linkComputer));
 	const provider = store.add(new MdReferencesProvider(getLsConfiguration({}), engine, workspace, tocProvider, linkCache, nulLogger));
 	const refs = await provider.provideReferences(doc, pos, { includeDeclaration: true }, noopToken);
 	return refs.sort((a, b) => {

--- a/src/test/rename.test.ts
+++ b/src/test/rename.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import * as lsp from 'vscode-languageserver-types';
 import { URI } from 'vscode-uri';
 import { getLsConfiguration } from '../config';
-import { createWorkspaceLinkCache } from '../languageFeatures/documentLinks';
+import { createWorkspaceLinkCache, MdLinkComputer } from '../languageFeatures/documentLinks';
 import { MdReferencesProvider } from '../languageFeatures/references';
 import { MdRenameProvider } from '../languageFeatures/rename';
 import { githubSlugifier } from '../slugify';
@@ -30,7 +30,8 @@ function prepareRename(store: DisposableStore, doc: InMemoryDocument, pos: lsp.P
 	const config = getLsConfiguration({});
 	const engine = createNewMarkdownEngine();
 	const tocProvider = store.add(new MdTableOfContentsProvider(engine, workspace, nulLogger));
-	const linkCache = store.add(createWorkspaceLinkCache(engine, workspace));
+	const linkComputer = new MdLinkComputer(engine, workspace);
+	const linkCache = store.add(createWorkspaceLinkCache(workspace, linkComputer));
 	const referenceComputer = store.add(new MdReferencesProvider(config, engine, workspace, tocProvider, linkCache, nulLogger));
 	const renameProvider = store.add(new MdRenameProvider(config, workspace, referenceComputer, githubSlugifier, nulLogger));
 	return renameProvider.prepareRename(doc, pos, noopToken);
@@ -43,7 +44,8 @@ function getRenameEdits(store: DisposableStore, doc: InMemoryDocument, pos: lsp.
 	const config = getLsConfiguration({});
 	const engine = createNewMarkdownEngine();
 	const tocProvider = store.add(new MdTableOfContentsProvider(engine, workspace, nulLogger));
-	const linkCache = store.add(createWorkspaceLinkCache(engine, workspace));
+	const linkComputer = new MdLinkComputer(engine, workspace);
+	const linkCache = store.add(createWorkspaceLinkCache(workspace, linkComputer));
 	const referencesProvider = store.add(new MdReferencesProvider(config, engine, workspace, tocProvider, linkCache, nulLogger));
 	const renameProvider = store.add(new MdRenameProvider(config, workspace, referencesProvider, githubSlugifier, nulLogger));
 	return renameProvider.provideRenameEdits(doc, pos, newName, noopToken);

--- a/src/test/workspaceSymbol.test.ts
+++ b/src/test/workspaceSymbol.test.ts
@@ -6,7 +6,7 @@ import * as assert from 'assert';
 import * as lsp from 'vscode-languageserver-types';
 import { IWorkspace } from '..';
 import { getLsConfiguration } from '../config';
-import { MdLinkProvider } from '../languageFeatures/documentLinks';
+import { MdLinkComputer, MdLinkProvider } from '../languageFeatures/documentLinks';
 import { MdDocumentSymbolProvider } from '../languageFeatures/documentSymbols';
 import { MdWorkspaceSymbolProvider } from '../languageFeatures/workspaceSymbols';
 import { MdTableOfContentsProvider } from '../tableOfContents';
@@ -21,7 +21,8 @@ import { joinLines, withStore, workspacePath } from './util';
 function getWorkspaceSymbols(store: DisposableStore, workspace: IWorkspace, query = ''): Promise<lsp.WorkspaceSymbol[]> {
 	const engine = createNewMarkdownEngine();
 	const tocProvider = store.add(new MdTableOfContentsProvider(engine, workspace, nulLogger));
-	const linkProvider = store.add(new MdLinkProvider(getLsConfiguration({}), engine, workspace, tocProvider, nulLogger));
+	const linkComputer = new MdLinkComputer(engine, workspace);
+	const linkProvider = store.add(new MdLinkProvider(getLsConfiguration({}), workspace, linkComputer, tocProvider, nulLogger));
 	const symbolProvider = new MdDocumentSymbolProvider(tocProvider, linkProvider, nulLogger);
 	const workspaceSymbolProvider = store.add(new MdWorkspaceSymbolProvider(workspace, symbolProvider));
 	return workspaceSymbolProvider.provideWorkspaceSymbols(query, noopToken);


### PR DESCRIPTION
See https://github.com/microsoft/vscode-markdown-languageservice/issues/7#issuecomment-1286220696 for discussion on motivation.

See [here for a proof-of-concept implementation](https://github.com/dsanders11/electron/blob/f95bcd81d6df4b978d3faf9afcd8cc10f87af87d/script/lib/markdown.ts#L161-L301) of `IMdLinkComputer` using `mdast` to gather the links. It's incomplete as it doesn't bother to set any of the sub-ranges correctly, since the intended use-case is simply to gather the diagnostics about links and the line number alone is sufficient for the intended output. That implementation also won't be able to detect broken reference links (where the definition is missing) since `mdast` just considers those as text in a paragraph so the information isn't available in the AST. It is of course also inefficient since it fully parses the Markdown twice since there are two different implementations, but that wasn't an issue for the intended use-case (pulls all diagnostics for ~225 files in a few seconds).