### PR TITLE
Add support for cross workspace header completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.0-alpha.4 UNRELEASED
+- Add support for cross workspace header completions when triggered on `##`.
+
 ## 0.3.0-alpha.3 November 30, 2022
 - Republish with missing types files.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-markdown-languageservice",
-  "version": "0.3.0-alpha.3",
+  "version": "0.3.0-alpha.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-markdown-languageservice",
-      "version": "0.3.0-alpha.3",
+      "version": "0.3.0-alpha.4",
       "license": "MIT",
       "dependencies": {
         "@vscode/l10n": "^0.0.10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-markdown-languageservice",
   "description": "Markdown language service",
-  "version": "0.3.0-alpha.3",
+  "version": "0.3.0-alpha.4",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -244,7 +244,7 @@ export function createLanguageService(init: LanguageServiceInitialization): IMdL
 
 	return Object.freeze<IMdLanguageService>({
 		dispose: () => {
-			linkCache.dispose(); 
+			linkCache.dispose();
 			tocProvider.dispose();
 			workspaceSymbolProvider.dispose();
 			linkProvider.dispose();
@@ -269,7 +269,7 @@ export function createLanguageService(init: LanguageServiceInitialization): IMdL
 		getRenameFilesInWorkspaceEdit: fileRenameProvider.getRenameFilesInWorkspaceEdit.bind(fileRenameProvider),
 		getCodeActions: async (doc: ITextDocument, range: lsp.Range, context: lsp.CodeActionContext, token: CancellationToken): Promise<lsp.CodeAction[]> => {
 			return (await Promise.all([
-				extractCodeActionProvider.getActions(doc, range, context, token), 
+				extractCodeActionProvider.getActions(doc, range, context, token),
 				Array.from(removeLinkDefinitionActionProvider.getActions(doc, range, context)),
 			])).flat();
 		},

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export { LsConfiguration } from './config';
 export { DiagnosticCode, DiagnosticLevel, DiagnosticOptions, IPullDiagnosticsManager } from './languageFeatures/diagnostics';
 export { ResolvedDocumentLinkTarget } from './languageFeatures/documentLinks';
 export { FileRename } from './languageFeatures/fileRename';
+export { MdPathCompletionOptions as MdCompletionOptions } from './languageFeatures/pathCompletions';
 export { RenameNotSupportedAtLocationError } from './languageFeatures/rename';
 export { ILogger, LogLevel } from './logging';
 export { IMdParser, Token } from './parser';
@@ -226,7 +227,7 @@ export function createLanguageService(init: LanguageServiceInitialization): IMdL
 	const smartSelectProvider = new MdSelectionRangeProvider(init.parser, tocProvider, logger);
 	const foldingProvider = new MdFoldingProvider(init.parser, tocProvider, logger);
 	const linkProvider = new MdLinkProvider(config, init.parser, init.workspace, tocProvider, logger);
-	const pathCompletionProvider = new MdPathCompletionProvider(config, init.workspace, init.parser, linkProvider);
+	const pathCompletionProvider = new MdPathCompletionProvider(config, init.workspace, init.parser, linkProvider, tocProvider);
 	const linkCache = createWorkspaceLinkCache(init.parser, init.workspace);
 	const referencesProvider = new MdReferencesProvider(config, init.parser, init.workspace, tocProvider, linkCache, logger);
 	const definitionsProvider = new MdDefinitionProvider(config, init.workspace, tocProvider, linkCache);
@@ -268,7 +269,7 @@ export function createLanguageService(init: LanguageServiceInitialization): IMdL
 		getRenameFilesInWorkspaceEdit: fileRenameProvider.getRenameFilesInWorkspaceEdit.bind(fileRenameProvider),
 		getCodeActions: async (doc: ITextDocument, range: lsp.Range, context: lsp.CodeActionContext, token: CancellationToken): Promise<lsp.CodeAction[]> => {
 			return (await Promise.all([
-				extractCodeActionProvider.getActions(doc, range, context, token),
+				extractCodeActionProvider.getActions(doc, range, context, token), 
 				Array.from(removeLinkDefinitionActionProvider.getActions(doc, range, context)),
 			])).flat();
 		},

--- a/src/languageFeatures/rename.ts
+++ b/src/languageFeatures/rename.ts
@@ -268,9 +268,13 @@ export function getLinkRenameText(workspace: IWorkspace, source: MdLinkSource, n
 		return '/' + path.posix.relative(root.resource.path, newPath.path);
 	}
 
-	const rootDir = Utils.dirname(source.resource);
-	if (rootDir.scheme === newPath.scheme && rootDir.scheme !== Schemes.untitled) {
-		let newLink = path.posix.relative(rootDir.path, newPath.path);
+	return computeRelativePath(source.resource, newPath, preferDotSlash);
+}
+
+export function computeRelativePath(fromDoc: URI, toDoc: URI, preferDotSlash = false): string | undefined {
+	if (fromDoc.scheme === toDoc.scheme && fromDoc.scheme !== Schemes.untitled) {
+		const rootDir = Utils.dirname(fromDoc);
+		let newLink = path.posix.relative(rootDir.path, toDoc.path);
 		if (preferDotSlash && !(newLink.startsWith('../') || newLink.startsWith('..\\'))) {
 			newLink = './' + newLink;
 		}

--- a/src/languageFeatures/workspaceSymbols.ts
+++ b/src/languageFeatures/workspaceSymbols.ts
@@ -13,7 +13,7 @@ import { MdDocumentSymbolProvider } from './documentSymbols';
 
 export class MdWorkspaceSymbolProvider extends Disposable {
 
-	readonly #cache: MdWorkspaceInfoCache<lsp.SymbolInformation[]>;
+	readonly #cache: MdWorkspaceInfoCache<readonly lsp.SymbolInformation[]>;
 	readonly #symbolProvider: MdDocumentSymbolProvider;
 
 	constructor(
@@ -44,7 +44,7 @@ export class MdWorkspaceSymbolProvider extends Disposable {
 		return Array.from(this.#toSymbolInformation(document.uri, docSymbols));
 	}
 
-	*#toSymbolInformation(uri: string, docSymbols: lsp.DocumentSymbol[]): Iterable<lsp.SymbolInformation> {
+	*#toSymbolInformation(uri: string, docSymbols: readonly lsp.DocumentSymbol[]): Iterable<lsp.SymbolInformation> {
 		for (const symbol of docSymbols) {
 			yield {
 				name: symbol.name,


### PR DESCRIPTION
Fixes #110

Lets you type `[text](##` to see suggestions for every header in current workspace. Accepting one of these suggestions inserts a link to it