### PR TITLE
Add preferredMdPathExtensionStyle setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.3.0-alpha.4 UNRELEASED
+## 0.3.0-alpha.4 February 1, 2023
 - Add support for cross workspace header completions when triggered on `##`.
+- Add `preferredMdPathExtensionStyle` configuration option to control if generated paths to Markdown files should include or drop the file extension.
 
 ## 0.3.0-alpha.3 November 30, 2022
 - Republish with missing types files.

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,19 @@ export interface LsConfiguration {
 	 * List of path globs that should be excluded from cross-file operations.
 	 */
 	readonly excludePaths: readonly string[];
+
+	/**
+	 * Preferred style for file paths to {@link markdownFileExtensions markdown files}.
+	 * 
+	 * This is used for paths added by the language service, such as for path completions and on file renames.
+	 * 
+	 * Valid values:
+	 * 
+	 * - `auto` — Try to maintain the existing of the path.
+	 * - `includeExtension` — Include the file extension when possible.
+	 * - `removeExtension` — Drop the file extension when possible.
+	 */
+	readonly preferredMdPathExtensionStyle?: 'auto' | 'includeExtension' | 'removeExtension';
 }
 
 export const defaultMarkdownFileExtension = 'md';

--- a/src/languageFeatures/codeActions/extractLinkDef.ts
+++ b/src/languageFeatures/codeActions/extractLinkDef.ts
@@ -105,7 +105,7 @@ export class MdExtractLinkDefinitionCodeActionProvider {
 		return {
 			title: MdExtractLinkDefinitionCodeActionProvider.genericTitle,
 			kind: MdExtractLinkDefinitionCodeActionProvider.#kind,
-			edit: builder.renameFragment(),
+			edit: builder.getEdit(),
 			command: {
 				command: 'vscodeMarkdownLanguageservice.rename',
 				title: 'Rename',

--- a/src/languageFeatures/codeActions/removeLinkDefinition.ts
+++ b/src/languageFeatures/codeActions/removeLinkDefinition.ts
@@ -57,6 +57,6 @@ export class MdRemoveLinkDefinitionCodeActionProvider {
 		const range = definition.source.range;
 		builder.replace(getDocUri(doc), makeRange(range.start.line, 0, range.start.line + 1, 0), '');
 
-		return { title, kind: lsp.CodeActionKind.QuickFix, edit: builder.renameFragment() };
+		return { title, kind: lsp.CodeActionKind.QuickFix, edit: builder.getEdit() };
 	}
 }

--- a/src/languageFeatures/diagnostics.ts
+++ b/src/languageFeatures/diagnostics.ts
@@ -14,7 +14,7 @@ import { translatePosition } from '../types/position';
 import { modifyRange } from '../types/range';
 import { getDocUri, ITextDocument } from '../types/textDocument';
 import { Disposable, IDisposable } from '../util/dispose';
-import { looksLikeMarkdownPath } from '../util/file';
+import { looksLikeMarkdownUri } from '../util/file';
 import { Limiter } from '../util/limiter';
 import { ResourceMap } from '../util/resourceMap';
 import { FileStat, IWorkspace, IWorkspaceWithWatching, statLinkToMarkdownFile } from '../workspace';
@@ -420,7 +420,7 @@ export class DiagnosticComputer {
 	}
 
 	#isMarkdownPath(resolvedHrefPath: URI) {
-		return this.#workspace.hasMarkdownDocument(resolvedHrefPath) || looksLikeMarkdownPath(this.#configuration, resolvedHrefPath);
+		return this.#workspace.hasMarkdownDocument(resolvedHrefPath) || looksLikeMarkdownUri(this.#configuration, resolvedHrefPath);
 	}
 
 	#isIgnoredLink(options: DiagnosticOptions, link: string): boolean {

--- a/src/languageFeatures/references.ts
+++ b/src/languageFeatures/references.ts
@@ -13,7 +13,7 @@ import { translatePosition } from '../types/position';
 import { areRangesEqual, modifyRange, rangeContains } from '../types/range';
 import { getDocUri, ITextDocument } from '../types/textDocument';
 import { Disposable } from '../util/dispose';
-import { looksLikeMarkdownPath } from '../util/file';
+import { looksLikeMarkdownUri } from '../util/file';
 import { IWorkspace, statLinkToMarkdownFile } from '../workspace';
 import { MdWorkspaceInfoCache } from '../workspaceCache';
 import { HrefKind, looksLikeLinkToResource, MdLink, MdLinkKind } from './documentLinks';
@@ -269,7 +269,7 @@ export class MdReferencesProvider extends Disposable {
 	}
 
 	#isMarkdownPath(resolvedHrefPath: URI) {
-		return this.#workspace.hasMarkdownDocument(resolvedHrefPath) || looksLikeMarkdownPath(this.#configuration, resolvedHrefPath);
+		return this.#workspace.hasMarkdownDocument(resolvedHrefPath) || looksLikeMarkdownUri(this.#configuration, resolvedHrefPath);
 	}
 
 	*#findLinksToFile(resource: URI, links: readonly MdLink[], sourceLink: MdLink | undefined): Iterable<MdReference> {

--- a/src/test/pathCompletion.test.ts
+++ b/src/test/pathCompletion.test.ts
@@ -355,6 +355,26 @@ suite('Path completions', () => {
 		]);
 	}));
 
+	test('Should allowing configuring if md file suggestions include .md file extension', withStore(async (store) => {
+		const workspace = new InMemoryWorkspace([
+			new InMemoryDocument(workspacePath('a.md'), ''),
+			new InMemoryDocument(workspacePath('b.md'), ''),
+			new InMemoryDocument(workspacePath('sub', 'foo.md'), ''),
+		]);
+
+		const completions = await getCompletionsAtCursor(store, workspacePath('new.md'), joinLines(
+			`[](./${CURSOR}`,
+			``,
+			`# A b C`,
+		), workspace, { preferredMdPathExtensionStyle: 'removeExtension' });
+
+		assertCompletionsEqual(completions, [
+			{ label: 'a' },
+			{ label: 'b' },
+			{ label: 'sub/' },
+		]);
+	}));
+
 	suite('Cross file header completions', () => {
 
 		test('Should return completions for headers in current doc', withStore(async (store) => {
@@ -485,6 +505,26 @@ suite('Path completions', () => {
 			assertCompletionsEqual(completions, [
 				{ label: '#a-b-c', insertText: '../a b.md#a-b-c' },
 				{ label: '#x-y-z', insertText: '../sub space/other sub/c d.md#x-y-z' },
+			]);
+		}));
+
+		test('Should allowing configuring if md file suggestions include .md file extension', withStore(async (store) => {
+			const workspace = new InMemoryWorkspace([
+				new InMemoryDocument(workspacePath('a.md'), joinLines(
+					'# A b C',
+				)),
+				new InMemoryDocument(workspacePath('sub', 'b.md'), joinLines(
+					'# x Y z',
+				)),
+			]);
+
+			const completions = await getCompletionsAtCursor(store, workspacePath('sub', 'new.md'), joinLines(
+				`[](##${CURSOR}`,
+			), workspace, { preferredMdPathExtensionStyle: 'removeExtension' }, { includeWorkspaceHeaderCompletions: true });
+
+			assertCompletionsEqual(completions, [
+				{ label: '#a-b-c', insertText: '../a#a-b-c' },
+				{ label: '#x-y-z', insertText: 'b#x-y-z' },
 			]);
 		}));
 	});

--- a/src/util/editBuilder.ts
+++ b/src/util/editBuilder.ts
@@ -30,7 +30,7 @@ export class WorkspaceEditBuilder {
 		edits.push(edit);
 	}
 
-	renameFragment(): lsp.WorkspaceEdit {
+	getEdit(): lsp.WorkspaceEdit {
 		// We need to convert changes into `documentChanges` or else they get dropped
 		const textualChanges = Object.entries(this.#changes).map(([uri, edits]): lsp.TextDocumentEdit => {
 			return lsp.TextDocumentEdit.create({ uri, version: null }, edits);

--- a/src/util/file.ts
+++ b/src/util/file.ts
@@ -3,9 +3,18 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as path from 'path';
 import { URI, Utils } from 'vscode-uri';
 import { LsConfiguration } from '../config';
 
-export function looksLikeMarkdownPath(config: LsConfiguration, resolvedHrefPath: URI) {
-	return config.markdownFileExtensions.includes(Utils.extname(URI.from(resolvedHrefPath)).toLowerCase().replace('.', ''));
+export function looksLikeMarkdownUri(config: LsConfiguration, resolvedHrefPath: URI): boolean {
+	return looksLikeMarkdownExt(config, Utils.extname(resolvedHrefPath));
+}
+
+export function looksLikeMarkdownFilePath(config: LsConfiguration, fileName: string): boolean {
+	return looksLikeMarkdownExt(config, path.extname(fileName));
+}
+
+function looksLikeMarkdownExt(config: LsConfiguration, rawExt: string): boolean {
+	return config.markdownFileExtensions.includes(rawExt.toLowerCase().replace('.', ''));
 }

--- a/src/util/path.ts
+++ b/src/util/path.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as path from 'path';
-import { URI } from 'vscode-uri';
+import { URI, Utils } from 'vscode-uri';
+import { Schemes } from './schemes';
 
 export function isParentDir(parent: URI, maybeChild: URI): boolean {
 	if (parent.scheme === maybeChild.scheme && parent.authority === maybeChild.authority) {
@@ -12,4 +13,17 @@ export function isParentDir(parent: URI, maybeChild: URI): boolean {
 		return !relative.startsWith('..');
 	}
 	return false;
+}
+
+export function computeRelativePath(fromDoc: URI, toDoc: URI, preferDotSlash = false): string | undefined {
+	if (fromDoc.scheme === toDoc.scheme && fromDoc.scheme !== Schemes.untitled) {
+		const rootDir = Utils.dirname(fromDoc);
+		let newLink = path.posix.relative(rootDir.path, toDoc.path);
+		if (preferDotSlash && !(newLink.startsWith('../') || newLink.startsWith('..\\'))) {
+			newLink = './' + newLink;
+		}
+		return newLink;
+	}
+
+	return undefined;
 }


### PR DESCRIPTION
Controls if completions to markdown files should include or drop the file extension (`.md`)