### PR TITLE
Add allow returning workspace header completions on single `#`

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,26 @@
 import * as picomatch from 'picomatch';
 import { URI } from 'vscode-uri';
 
+/**
+ * Preferred style for file paths to {@link markdownFileExtensions markdown files}.
+ */
+export enum PreferredMdPathExtensionStyle {
+	/**
+	 * Try to maintain the existing of the path.
+	 */
+	auto = 'auto',
+
+	/**
+	 * Include the file extension when possible.
+	 */
+	includeExtension = 'includeExtension',
+
+	/**
+	 * Drop the file extension when possible.
+	 */
+	removeExtension = 'removeExtension',
+}
+
 export interface LsConfiguration {
 	/**
 	 * List of file extensions should be considered markdown.
@@ -35,14 +55,8 @@ export interface LsConfiguration {
 	 * Preferred style for file paths to {@link markdownFileExtensions markdown files}.
 	 * 
 	 * This is used for paths added by the language service, such as for path completions and on file renames.
-	 * 
-	 * Valid values:
-	 * 
-	 * - `auto` — Try to maintain the existing of the path.
-	 * - `includeExtension` — Include the file extension when possible.
-	 * - `removeExtension` — Drop the file extension when possible.
 	 */
-	readonly preferredMdPathExtensionStyle?: 'auto' | 'includeExtension' | 'removeExtension';
+	readonly preferredMdPathExtensionStyle?: PreferredMdPathExtensionStyle;
 }
 
 export const defaultMarkdownFileExtension = 'md';

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,11 +28,11 @@ import { MdTableOfContentsProvider } from './tableOfContents';
 import { ITextDocument } from './types/textDocument';
 import { isWorkspaceWithFileWatching, IWorkspace } from './workspace';
 
-export { LsConfiguration } from './config';
+export { LsConfiguration, PreferredMdPathExtensionStyle } from './config';
 export { DiagnosticCode, DiagnosticLevel, DiagnosticOptions, IPullDiagnosticsManager } from './languageFeatures/diagnostics';
 export { ResolvedDocumentLinkTarget } from './languageFeatures/documentLinks';
 export { FileRename } from './languageFeatures/fileRename';
-export { MdPathCompletionOptions as MdCompletionOptions } from './languageFeatures/pathCompletions';
+export { IncludeWorkspaceHeaderCompletions, MdPathCompletionOptions } from './languageFeatures/pathCompletions';
 export { RenameNotSupportedAtLocationError } from './languageFeatures/rename';
 export { ILogger, LogLevel } from './logging';
 export { IMdParser, Token } from './parser';

--- a/src/test/fileRename.test.ts
+++ b/src/test/fileRename.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import * as lsp from 'vscode-languageserver-types';
 import { URI } from 'vscode-uri';
-import { getLsConfiguration, LsConfiguration } from '../config';
+import { getLsConfiguration, LsConfiguration, PreferredMdPathExtensionStyle } from '../config';
 import { createWorkspaceLinkCache } from '../languageFeatures/documentLinks';
 import { FileRenameResponse, MdFileRenameProvider } from '../languageFeatures/fileRename';
 import { MdReferencesProvider } from '../languageFeatures/references';
@@ -127,7 +127,7 @@ suite('File Rename', () => {
 		const oldUri = workspacePath('old.md');
 		const newUri = workspacePath('new.md');
 
-		const response = await getFileRenameEdits(store, [{ oldUri, newUri }], workspace, { preferredMdPathExtensionStyle: 'removeExtension' });
+		const response = await getFileRenameEdits(store, [{ oldUri, newUri }], workspace, { preferredMdPathExtensionStyle: PreferredMdPathExtensionStyle.removeExtension });
 		assertEditsEqual(response!.edit, {
 			uri: docUri, edits: [
 				lsp.TextEdit.replace(makeRange(0, 6, 0, 13), '/new'),


### PR DESCRIPTION
Adds setting to include workspace header completions when you type a single `#` instead of requiring `##`

This also converts an existing setting to use an enum for better documentation.