### PR TITLE
Allow language service configuration to be changed dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.0-alpha.5 February 20, 2023
+- Allow language service configuration to be changed dynamically. 
+
 ## 0.3.0-alpha.4 February 1, 2023
 - Add support for cross workspace header completions when triggered on `##`.
 - Add `preferredMdPathExtensionStyle` configuration option to control if generated paths to Markdown files should include or drop the file extension.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-markdown-languageservice",
-  "version": "0.3.0-alpha.4",
+  "version": "0.3.0-alpha.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-markdown-languageservice",
-      "version": "0.3.0-alpha.4",
+      "version": "0.3.0-alpha.5",
       "license": "MIT",
       "dependencies": {
         "@vscode/l10n": "^0.0.10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-markdown-languageservice",
   "description": "Markdown language service",
-  "version": "0.3.0-alpha.4",
+  "version": "0.3.0-alpha.5",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "engines": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -79,10 +79,11 @@ const defaultConfig: LsConfiguration = {
 };
 
 export function getLsConfiguration(overrides: Partial<LsConfiguration>): LsConfiguration {
-	return {
-		...defaultConfig,
-		...overrides,
-	};
+	return new Proxy<LsConfiguration>(Object.create(null), {
+		get(_target, p: keyof LsConfiguration, _receiver) {
+			return p in overrides ? overrides[p] : defaultConfig[p];
+		},
+	});
 }
 
 export function isExcludedPath(configuration: LsConfiguration, uri: URI): boolean {


### PR DESCRIPTION
Switches to use a Proxy instead of a spread so that getters are properly preserved

Also bumps version so we can release this change