### PR TITLE
Fix some edge cases around path completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.0-alpha.5 — June 5, 2023
 - Make rename and path completions escape angle brackets when inside of angle bracket links.
-- Try removing angle brackets from links if the link no longer requires it.
+- On rename, try removing angle brackets from links if the link no longer requires it.
 - Don't encode paths as aggressively on path completions.
 
 ## 0.4.0-alpha.4 — June 2, 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
 ## 0.4.0-alpha.5 — June 5, 2023
-- Escape angle bracket when needed inside of angle bracket links.
+- Make rename and path completions escape angle brackets when inside of angle bracket links.
 - Try removing angle brackets from links if the link no longer requires it.
+- Don't encode paths as aggressively on path completions.
 
 ## 0.4.0-alpha.4 — June 2, 2023
 - Fix link detection for escaped angle brackets.

--- a/src/languageFeatures/pathCompletions.ts
+++ b/src/languageFeatures/pathCompletions.ts
@@ -423,7 +423,7 @@ export class MdPathCompletionProvider {
 			}
 
 			const normalizedPath = this.#normalizeFileNameCompletion(rawPath);
-			const path = context.isAngleBracketPath ? normalizedPath : encodeURI(normalizedPath);
+			const path = this.#getPathInsertText(context, normalizedPath);
 			for (const entry of toc.entries) {
 				const completionItem = this.#createHeaderCompletion(entry, insertionRange, replacementRange, path);
 				completionItem.filterText = '#' + completionItem.label;
@@ -477,7 +477,7 @@ export class MdPathCompletionProvider {
 			}
 
 			const isDir = type.isDirectory;
-			const newText = this.#getInsertText(context, name) + (isDir ? '/' : '');
+			const newText = this.#getPathInsertText(context, name) + (isDir ? '/' : '');
 			const label = isDir ? name + '/' : name;
 			yield {
 				label,
@@ -494,7 +494,7 @@ export class MdPathCompletionProvider {
 		}
 	}
 
-	#getInsertText(context: PathCompletionContext, name: string): string {
+	#getPathInsertText(context: PathCompletionContext, name: string): string {
 		if (context.kind === CompletionContextKind.HtmlAttribute) {
 			return name
 				.replaceAll(`"`, '&quot;')
@@ -505,7 +505,6 @@ export class MdPathCompletionProvider {
 			return escapeForAngleBracketLink(name);
 		}
 
-		
 		if (!hasBalancedParens(name)) {
 			name = name.replace(/([()])/g, '\\$1');
 		}

--- a/src/languageFeatures/pathCompletions.ts
+++ b/src/languageFeatures/pathCompletions.ts
@@ -21,7 +21,7 @@ import { r } from '../util/string';
 import { FileStat, IWorkspace, getWorkspaceFolder, openLinkToMarkdownFile } from '../workspace';
 import { MdWorkspaceInfoCache } from '../workspaceCache';
 import { MdLinkProvider, htmlTagPathAttrs } from './documentLinks';
-import { escapeForAngleBracketLink } from './rename';
+import { escapeForAngleBracketLink, hasBalancedParens } from '../util/mdLinks';
 
 enum CompletionContextKind {
 	/** `[...](|)` */
@@ -495,8 +495,19 @@ export class MdPathCompletionProvider {
 	}
 
 	#getInsertText(context: PathCompletionContext, name: string): string {
+		if (context.kind === CompletionContextKind.HtmlAttribute) {
+			return name
+				.replaceAll(`"`, '&quot;')
+				.replaceAll(`'`, '&apos;');
+		}
+
 		if (context.isAngleBracketPath) {
 			return escapeForAngleBracketLink(name);
+		}
+
+		
+		if (!hasBalancedParens(name)) {
+			name = name.replace(/([()])/g, '\\$1');
 		}
 
 		return name.replaceAll(' ', '%20');

--- a/src/languageFeatures/rename.ts
+++ b/src/languageFeatures/rename.ts
@@ -299,37 +299,37 @@ export function getLinkRenameEdit(link: MdLink, newName: string): lsp.TextEdit {
 			const range = makeRange(translatePosition(pathRange.start, { characterDelta: -1 }), translatePosition(pathRange.end, { characterDelta: 1 }));
 			return { range, newText: newLinkText };
 		} else {
-			return { range: pathRange, newText: escapeAngleBracketLinkContents(newLinkText) };
+			return { range: pathRange, newText: escapeForAngleBracketLink(newLinkText) };
 		}
 	}
 
 	// We might need to use angle brackets for the link
 	if (needsAngleBracketLink(newLinkText)) {
-		return { range: pathRange, newText: `<${escapeAngleBracketLinkContents(newLinkText)}>` };
+		return { range: pathRange, newText: `<${escapeForAngleBracketLink(newLinkText)}>` };
 	}
 
 	return { range: pathRange, newText: newLinkText };
 }
 
-function escapeAngleBracketLinkContents(newLinkText: string) {
-	return newLinkText.replace(/([<>])/g, '\\$1');
+export function escapeForAngleBracketLink(linkText: string) {
+	return linkText.replace(/([<>])/g, '\\$1');
 }
 
-function needsAngleBracketLink(mdPath: string) {
+function needsAngleBracketLink(linkText: string) {
 	// Links with whitespace or control characters must be enclosed in brackets
 	// eslint-disable-next-line no-control-regex
-	if (mdPath.startsWith('<') || /\s|[\u007F\u0000-\u001f]/.test(mdPath)) {
+	if (linkText.startsWith('<') || /\s|[\u007F\u0000-\u001f]/.test(linkText)) {
 		return true;
 	}
 
 	// Check if the link has mis-matched parens
-	if (!/[\(\)]/.test(mdPath)) {
+	if (!/[\(\)]/.test(linkText)) {
 		return false;
 	}
 
 	let previousChar = '';
 	let nestingCount = 0;
-	for (const char of mdPath) {
+	for (const char of linkText) {
 		if (char === '(' && previousChar !== '\\') {
 			nestingCount++;
 		} else if (char === ')' && previousChar !== '\\') {

--- a/src/test/pathCompletion.test.ts
+++ b/src/test/pathCompletion.test.ts
@@ -632,6 +632,22 @@ suite('Path completions', () => {
 				{ label: '#x-y-z', insertText: 'b#x-y-z' },
 			]);
 		}));
+
+		test('Should support multibyte character paths', withStore(async (store) => {
+			const workspace = store.add(new InMemoryWorkspace([
+				new InMemoryDocument(workspacePath('テ ス ト.md'), joinLines(
+					`# Header`
+				)),
+			]));
+	
+			const completions = await getCompletionsAtCursorForFileContents(store, workspacePath('new.md'), joinLines(
+				`[](##${CURSOR}`,
+			), workspace, undefined, { includeWorkspaceHeaderCompletions: IncludeWorkspaceHeaderCompletions.onDoubleHash });
+	
+			assertCompletionsEqual(completions, [
+				{ label: '#header', insertText: 'テ%20ス%20ト.md#header' },
+			]);
+		}));
 	});
 
 	suite('Html attribute path completions', () => {

--- a/src/test/pathCompletion.test.ts
+++ b/src/test/pathCompletion.test.ts
@@ -382,6 +382,40 @@ suite('Path completions', () => {
 		]);
 	}));
 
+	test('Should support multibyte character paths', withStore(async (store) => {
+		const workspace = store.add(new InMemoryWorkspace([
+			new InMemoryDocument(workspacePath('テスト1.md'), ''),
+			new InMemoryDocument(workspacePath('テスト', 'テスト2.md'), ''),
+			new InMemoryDocument(workspacePath('テ ス ト3.md'), ''),
+		]));
+
+		const completions = await getCompletionsAtCursorForFileContents(store, workspacePath('new.md'), joinLines(
+			`[](./${CURSOR}`,
+		), workspace);
+
+		assertCompletionsEqual(completions, [
+			{ label: 'テ ス ト3.md', insertText: 'テ%20ス%20ト3.md' },
+			{ label: 'テスト/' },
+			{ label: 'テスト1.md' },
+		]);
+	}));
+
+	test('Should escape angle brackets if in angle bracket link', withStore(async (store) => {
+		const workspace = store.add(new InMemoryWorkspace([
+			new InMemoryDocument(workspacePath('<a>.md'), ''),
+			new InMemoryDocument(workspacePath('a<b>c.md'), ''),
+		]));
+
+		const completions = await getCompletionsAtCursorForFileContents(store, workspacePath('new.md'), joinLines(
+			`[](<./${CURSOR}`,
+		), workspace);
+
+		assertCompletionsEqual(completions, [
+			{ label: '<a>.md', insertText: '\\<a\\>.md' },
+			{ label: 'a<b>c.md', insertText: 'a\\<b\\>c.md' },
+		]);
+	}));
+
 	suite('Cross file header completions', () => {
 
 		test('Should return completions for headers in current doc', withStore(async (store) => {

--- a/src/test/pathCompletion.test.ts
+++ b/src/test/pathCompletion.test.ts
@@ -416,6 +416,22 @@ suite('Path completions', () => {
 		]);
 	}));
 
+	test('Should escape mismatched parens', withStore(async (store) => {
+		const workspace = store.add(new InMemoryWorkspace([
+			new InMemoryDocument(workspacePath('(a).md'), ''),
+			new InMemoryDocument(workspacePath('a(b.md'), ''),
+		]));
+
+		const completions = await getCompletionsAtCursorForFileContents(store, workspacePath('new.md'), joinLines(
+			`[](./${CURSOR}`,
+		), workspace);
+
+		assertCompletionsEqual(completions, [
+			{ label: '(a).md', insertText: '(a).md' },
+			{ label: 'a(b.md', insertText: 'a\\(b.md' },
+		]);
+	}));
+
 	suite('Cross file header completions', () => {
 
 		test('Should return completions for headers in current doc', withStore(async (store) => {
@@ -690,6 +706,22 @@ suite('Path completions', () => {
 
 			assertCompletionsEqual(completions, [
 				{ label: 'new.md' },
+			]);
+		}));
+
+		test('Should escape quotes in html', withStore(async (store) => {
+			const workspace = store.add(new InMemoryWorkspace([
+				new InMemoryDocument(workspacePath(`double qu"ot"e.md`,), joinLines()),
+				new InMemoryDocument(workspacePath(`single qu'ot'e.md`,), joinLines()),
+			]));
+
+			const completions = await getCompletionsAtCursorForFileContents(store, workspacePath('new.md'), joinLines(
+				`some text <img src="./${CURSOR}"> more text`,
+			), workspace);
+
+			assertCompletionsEqual(completions, [
+				{ label: `double qu"ot"e.md`, insertText: 'double qu&quot;ot&quot;e.md' },
+				{ label: `single qu'ot'e.md`, insertText: 'single qu&apos;ot&apos;e.md' },
 			]);
 		}));
 	});

--- a/src/util/mdLinks.ts
+++ b/src/util/mdLinks.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+
+export function escapeForAngleBracketLink(linkText: string) {
+	return linkText.replace(/([<>])/g, '\\$1');
+}
+
+export function needsAngleBracketLink(linkText: string) {
+	// Links with whitespace or control characters must be enclosed in brackets
+	// eslint-disable-next-line no-control-regex
+	if (linkText.startsWith('<') || /\s|[\u007F\u0000-\u001f]/.test(linkText)) {
+		return true;
+	}
+
+	return !hasBalancedParens(linkText);
+}
+
+
+export function hasBalancedParens(linkText: string): boolean {
+	// Check if the link has balanced parens
+	if (!/[\(\)]/.test(linkText)) {
+		return true;
+	}
+
+	let previousChar = '';
+	let nestingCount = 0;
+	for (const char of linkText) {
+		if (char === '(' && previousChar !== '\\') {
+			nestingCount++;
+		} else if (char === ')' && previousChar !== '\\') {
+			nestingCount--;
+		}
+
+		if (nestingCount < 0) {
+			return false;
+		}
+
+		previousChar = char;
+	}
+
+	return nestingCount === 0;
+}
+
+

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"target": "es2022",
 		"lib": [
-			"ES2020",
+			"ES2021",
 		],
 		"sourceMap": true,
 		"module": "commonjs",


### PR DESCRIPTION
Fixes #17

With this change, we no longer call `encodeURI` for path completions. This usually was not needed. We then also better handle cases where paths have characters with special meanings