### PR TITLE
Fix link detection for few more reference link cases

### DIFF
--- a/src/test/diagnostic.test.ts
+++ b/src/test/diagnostic.test.ts
@@ -451,7 +451,37 @@ suite('Diagnostic Computer', () => {
 
 		const workspace = store.add(new InMemoryWorkspace([doc]));
 
-		const diagnostics = await getComputedDiagnostics(store, doc, workspace, { });
+		const diagnostics = await getComputedDiagnostics(store, doc, workspace, {});
+		assertDiagnosticsEqual(diagnostics, []);
+	}));
+
+	test('Should detect reference link shorthand with nested brackets', withStore(async (store) => {
+		const docUri = workspacePath('doc.md');
+		const doc = new InMemoryDocument(docUri, joinLines(
+			`[[test]]`,
+			``,
+			`[test]: http://example.com`,
+		));
+
+		const workspace = store.add(new InMemoryWorkspace([doc]));
+
+		const diagnostics = await getComputedDiagnostics(store, doc, workspace, {});
+		assertDiagnosticsEqual(diagnostics, []);
+	}));
+
+	test('Should detect reference links shorthand with escaped brackets', withStore(async (store) => {
+		const docUri = workspacePath('doc.md');
+		const doc = new InMemoryDocument(docUri, joinLines(
+			String.raw`[abc][\[test\]]`,
+			String.raw`[\[test\]][]`,
+			String.raw`[\[test\]]`,
+			String.raw``,
+			String.raw`[\[test\]]: http://example.com`,
+		));
+
+		const workspace = store.add(new InMemoryWorkspace([doc]));
+
+		const diagnostics = await getComputedDiagnostics(store, doc, workspace, {});
 		assertDiagnosticsEqual(diagnostics, []);
 	}));
 });

--- a/src/test/documentLinks.test.ts
+++ b/src/test/documentLinks.test.ts
@@ -662,6 +662,36 @@ suite('Link computer', () => {
 		]);
 	});
 
+	test('Should find reference link with nested brackets', async () => {
+		const links = await getLinksForText(joinLines(
+			`[[test]]`,
+			``,
+			`[test]: http://example.com`,
+		));
+
+		assertLinksEqual(links, [
+			makeRange(0, 2, 0, 6),
+			makeRange(2, 8, 2, 26),
+		]);
+	});
+
+	test('Should find reference link with escaped brackets', async () => {
+		const links = await getLinksForText(joinLines(
+			String.raw`[some text][\[test\]]`,
+			String.raw`[\[test\]][]`,
+			String.raw`[\[test\]]`,
+			String.raw``,
+			String.raw`[\[test\]]: http://example.com`,
+		));
+
+		assertLinksEqual(links, [
+			makeRange(0, 12, 0, 20),
+			makeRange(1, 1, 1, 9),
+			makeRange(2, 1, 2, 9),
+			makeRange(4, 12, 4, 30),
+		]);
+	});
+
 	test('Should find src in block html <img>', async () => {
 		const links = await getLinksForText(joinLines(
 			`<img src="cat.png">`,


### PR DESCRIPTION
Should now handle:

- `[[text]]` (this should treat `text` as the reference link)
- Reference contains escaped brackets