### PR TITLE
Fix inline code regexp

### DIFF
--- a/src/languageFeatures/documentLinks.ts
+++ b/src/languageFeatures/documentLinks.ts
@@ -329,7 +329,7 @@ const autoLinkPattern = /\<(\w+:[^\>\s]+)\>/g;
  */
 const definitionPattern = /^([\t ]*\[(?!\^)((?:\\\]|[^\]])+)\]:\s*)([^<]\S*|<(?:\\[<>]|[^<>])+>)/gm;
 
-const inlineCodePattern = /(^|[^`])(`+)((?:.+?|.*?(?:(?:\r?\n).+?)*?)(?:\r?\n)?\2)(?:$|[^`])/gm;
+const inlineCodePattern = /(?<!`)(`+)((?:.+?|.*?(?:(?:\r?\n).+?)*?)(?:\r?\n)?\1)(?!`)/gm;
 
 class NoLinkRanges {
 	public static compute(tokens: readonly Token[], document: ITextDocument): NoLinkRanges {
@@ -340,10 +340,10 @@ class NoLinkRanges {
 		const inlineRanges = new Map</* line number */ number, lsp.Range[]>();
 		const text = document.getText();
 		for (const match of text.matchAll(inlineCodePattern)) {
-			const startOffset = (match.index ?? 0) + match[1].length;
+			const startOffset = match.index ?? 0;
 			const startPosition = document.positionAt(startOffset);
 
-			const range: lsp.Range = { start: startPosition, end: document.positionAt(startOffset + match[3].length) };
+			const range: lsp.Range = { start: startPosition, end: document.positionAt(startOffset + match[0].length) };
 			for (let line = range.start.line; line <= range.end.line; ++line) {
 				let entry = inlineRanges.get(line);
 				if (!entry) {

--- a/src/test/diagnostic.test.ts
+++ b/src/test/diagnostic.test.ts
@@ -506,6 +506,18 @@ suite('Diagnostic Computer', () => {
 			makeRange(6, 5, 6, 11),
 		]);
 	}));
+
+	test('Should not detect errors in inline code (#153)', withStore(async (store) => {
+		const docUri = workspacePath('doc.md');
+		const doc = new InMemoryDocument(docUri, joinLines(
+			'- `[!xyz].js` `ab.js` `[^xyz].js` `[!x-z].js`。',
+		));
+
+		const workspace = store.add(new InMemoryWorkspace([doc]));
+
+		const diagnostics = await getComputedDiagnostics(store, doc, workspace, {});
+		assertDiagnosticsEqual(diagnostics, []);
+	}));
 });
 
 

--- a/src/test/documentLinks.test.ts
+++ b/src/test/documentLinks.test.ts
@@ -742,6 +742,14 @@ suite('Link computer', () => {
 			makeRange(2, 8, 2, 19),
 		]);
 	});
+
+	test('Should not find reference links in inline code (#153)', async () => {
+		const links = await getLinksForText(joinLines(
+			'- `[!xyz].js` `ab.js` `[^xyz].js` `[!x-z].js`。',
+		));
+
+		assertLinksEqual(links, []);
+	});
 });
 
 


### PR DESCRIPTION
Fixes #153

Now that negative lookaheads are supported in all envs, we can use them in this regexp