### PR TITLE
Fix catastrophic backtracking for link shorthand

### DIFF
--- a/src/test/documentLinks.test.ts
+++ b/src/test/documentLinks.test.ts
@@ -750,6 +750,15 @@ suite('Link computer', () => {
 
 		assertLinksEqual(links, []);
 	});
+
+	test('Should not catastrophical backtrack on slashes', async () => {
+		const links = await getLinksForText(joinLines(
+			`# symbol`,
+			String.raw`[\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\`,
+		));
+
+		assertLinksEqual(links, []);
+	});
 });
 
 


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/195756
https://github.com/microsoft/vscode/issues/195487

Also switches us to use named capture groups for readability