### PR TITLE
Use fuzzy matching for workspace symbol search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.4.0-alpha.9 — Unreleased
+- Use fuzzy matching for workspace symbol search.
+
 ## 0.4.0-alpha.8 — October 31, 2023
 - Fix potential catastrophic backtracking in a regular expression.
 - Fix some false positives for link validation.

--- a/src/languageFeatures/workspaceSymbols.ts
+++ b/src/languageFeatures/workspaceSymbols.ts
@@ -10,6 +10,7 @@ import { Disposable } from '../util/dispose';
 import { IWorkspace } from '../workspace';
 import { MdWorkspaceInfoCache } from '../workspaceCache';
 import { MdDocumentSymbolProvider } from './documentSymbols';
+import { fuzzyContains } from '../util/string';
 
 export class MdWorkspaceSymbolProvider extends Disposable {
 
@@ -33,7 +34,9 @@ export class MdWorkspaceSymbolProvider extends Disposable {
 		}
 
 		const normalizedQueryStr = query.toLowerCase();
-		return allSymbols.flat().filter(symbolInformation => symbolInformation.name.toLowerCase().includes(normalizedQueryStr));
+		return allSymbols.flat().filter(symbolInformation => {
+			return fuzzyContains(symbolInformation.name.toLowerCase(), normalizedQueryStr);
+		});
 	}
 
 	public async provideDocumentSymbolInformation(document: ITextDocument, token: CancellationToken): Promise<lsp.SymbolInformation[]> {

--- a/src/util/string.ts
+++ b/src/util/string.ts
@@ -8,3 +8,31 @@ export function isEmptyOrWhitespace(str: string): boolean {
 }
 
 export const r = String.raw;
+
+/**
+ * Checks if the characters of the provided query string are included in the
+ * target string. The characters do not have to be contiguous within the string.
+ */
+export function fuzzyContains(target: string, query: string): boolean {
+	if (target.length < query.length) {
+		return false; // impossible for query to be contained in target
+	}
+
+	const queryLen = query.length;
+	const targetLower = target.toLowerCase();
+
+	let index = 0;
+	let lastIndexOf = -1;
+	while (index < queryLen) {
+		const indexOf = targetLower.indexOf(query[index], lastIndexOf + 1);
+		if (indexOf < 0) {
+			return false;
+		}
+
+		lastIndexOf = indexOf;
+
+		index++;
+	}
+
+	return true;
+}


### PR DESCRIPTION
Loosens up matching so we only require the query characters to appear in order instead of as a substring