### PR TITLE
Don't recognized escaped links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.4.0-alpha.9 — Unreleased
 - Use fuzzy matching for workspace symbol search.
+- Fix some false positive link detection on escaped links.
 
 ## 0.4.0-alpha.8 — October 31, 2023
 - Fix potential catastrophic backtracking in a regular expression.

--- a/src/languageFeatures/documentLinks.ts
+++ b/src/languageFeatures/documentLinks.ts
@@ -271,6 +271,8 @@ function stripAngleBrackets(link: string) {
  * Matches `[text](link)` or `[text](<link>)`
  */
 const linkPattern = new RegExp(
+	r`(?<!\\)` + // Must not start with escape
+
 	// text
 	r`(!?\[` + // open prefix match -->
 	/**/r`(?:` +
@@ -322,12 +324,12 @@ const referenceLinkPattern = new RegExp(
 /**
  * Matches `<http://example.com>`
  */
-const autoLinkPattern = /\<(\w+:[^\>\s]+)\>/g;
+const autoLinkPattern = /(?<!\\)\<(\w+:[^\>\s]+)\>/g;
 
 /**
  * Matches `[text]: link`
  */
-const definitionPattern = /^([\t ]*\[(?!\^)((?:\\\]|[^\]])+)\]:\s*)([^<]\S*|<(?:\\[<>]|[^<>])+>)/gm;
+const definitionPattern = /^([\t ]*(?<!\\)\[(?!\^)((?:\\\]|[^\]])+)\]:\s*)([^<]\S*|<(?:\\[<>]|[^<>])+>)/gm;
 
 const inlineCodePattern = /(?<!`)(`+)((?:.+?|.*?(?:(?:\r?\n).+?)*?)(?:\r?\n)?\1)(?!`)/gm;
 

--- a/src/test/documentLinks.test.ts
+++ b/src/test/documentLinks.test.ts
@@ -302,6 +302,29 @@ suite('Link computer', () => {
 		]);
 	});
 
+	test('Should not include links with escaped leading characters (#15)', async () => {
+		const links = await getLinksForText(joinLines(
+			`\\[text](http://example.com)`,
+			`\\<http://example.com>`,
+			``,
+			`\\[def]: http://example.com`,
+		));
+		assertLinksEqual(links, []);
+	});
+
+	test('Should find angle bracket link in escaped link (#15)', async () => {
+		// Somewhat contrived example, but it's valid markdown and the auto links should be found
+		const links = await getLinksForText(joinLines(
+			`\\[text](<http://example.com>)`,
+			``,
+			`\\[text]: <http://example.com>`,
+		));
+		assertLinksEqual(links, [
+			makeRange(0, 9, 0, 27),
+			makeRange(2, 10, 2, 28),
+		]);
+	});
+
 	test('Should not consider links in code fenced with backticks', async () => {
 		const links = await getLinksForText(joinLines(
 			'```',


### PR DESCRIPTION
Fixes #15

Fixes a few more cases where escaped links were being recognized. Possible now that we can use negative lookbehind 