### PR TITLE
Fix the vscode-languageserver-* imports

### DIFF
--- a/example.cjs
+++ b/example.cjs
@@ -5,7 +5,7 @@
 const mdls = require('.');
 const MarkdownIt = require('markdown-it');
 const { URI } = require('vscode-uri');
-const { CancellationTokenSource, Emitter } = require('vscode-languageserver');
+const { CancellationTokenSource, Emitter } = require('vscode-languageserver-protocol');
 const { TextDocument } = require('vscode-languageserver-textdocument');
 
 // First we need to create the services that the markdown language service depends on.
@@ -16,12 +16,12 @@ const mdIt = MarkdownIt({ html: true });
 
 /** @type {mdls.IMdParser} */
 const parser = new class {
-	slugifier = mdls.githubSlugifier
+	slugifier = mdls.githubSlugifier;
 
 	async tokenize(document) {
 		return mdIt.parse(document.getText(), {});
 	}
-}
+};
 
 // Create a virtual document that holds our file content
 const myDocument = TextDocument.create(
@@ -73,7 +73,7 @@ const workspace = new class {
 
 	async readDirectory(/** @type {URI} */resource) {
 		// Not implemented
-		return []
+		return [];
 	}
 
 
@@ -106,7 +106,7 @@ async function main() {
 	const cts = new CancellationTokenSource();
 	try {
 		const symbols = await languageService.getDocumentSymbols(myDocument, { includeLinkDefinitions: true }, cts.token);
-		console.log(JSON.stringify(symbols, null, 2))
+		console.log(JSON.stringify(symbols, null, 2));
 	} finally {
 		cts.dispose();
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
         "@vscode/l10n": "^0.0.10",
         "node-html-parser": "^6.1.5",
         "picomatch": "^2.3.1",
-        "vscode-languageserver-textdocument": "^1.0.8",
-        "vscode-languageserver-types": "^3.17.3",
+        "vscode-languageserver-protocol": "^3.17.1",
         "vscode-uri": "^3.0.7"
       },
       "devDependencies": {
@@ -29,7 +28,7 @@
         "mkdirp": "^1.0.4",
         "mocha": "^10.0.0",
         "typescript": "^5.1.3",
-        "vscode-languageserver": "^8.0.1"
+        "vscode-languageserver-textdocument": "^1.0.8"
       },
       "engines": {
         "node": "*"
@@ -2525,28 +2524,14 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz",
       "integrity": "sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ==",
-      "dev": true,
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/vscode-languageserver": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.1.tgz",
-      "integrity": "sha512-sn7SjBwWm3OlmLtgg7jbM0wBULppyL60rj8K5HF0ny/MzN+GzPBX1kCvYdybhl7UW63V5V5tRVnyB8iwC73lSQ==",
-      "dev": true,
-      "dependencies": {
-        "vscode-languageserver-protocol": "3.17.1"
-      },
-      "bin": {
-        "installServerIntoExtension": "bin/installServerIntoExtension"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
       "version": "3.17.1",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz",
       "integrity": "sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==",
-      "dev": true,
       "dependencies": {
         "vscode-jsonrpc": "8.0.1",
         "vscode-languageserver-types": "3.17.1"
@@ -2555,18 +2540,13 @@
     "node_modules/vscode-languageserver-protocol/node_modules/vscode-languageserver-types": {
       "version": "3.17.1",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz",
-      "integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ==",
-      "dev": true
+      "integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ=="
     },
     "node_modules/vscode-languageserver-textdocument": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
-      "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q=="
-    },
-    "node_modules/vscode-languageserver-types": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
-      "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
+      "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q==",
+      "dev": true
     },
     "node_modules/vscode-uri": {
       "version": "3.0.7",
@@ -4553,23 +4533,12 @@
     "vscode-jsonrpc": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz",
-      "integrity": "sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ==",
-      "dev": true
-    },
-    "vscode-languageserver": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.1.tgz",
-      "integrity": "sha512-sn7SjBwWm3OlmLtgg7jbM0wBULppyL60rj8K5HF0ny/MzN+GzPBX1kCvYdybhl7UW63V5V5tRVnyB8iwC73lSQ==",
-      "dev": true,
-      "requires": {
-        "vscode-languageserver-protocol": "3.17.1"
-      }
+      "integrity": "sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ=="
     },
     "vscode-languageserver-protocol": {
       "version": "3.17.1",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz",
       "integrity": "sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==",
-      "dev": true,
       "requires": {
         "vscode-jsonrpc": "8.0.1",
         "vscode-languageserver-types": "3.17.1"
@@ -4578,20 +4547,15 @@
         "vscode-languageserver-types": {
           "version": "3.17.1",
           "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz",
-          "integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ==",
-          "dev": true
+          "integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ=="
         }
       }
     },
     "vscode-languageserver-textdocument": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
-      "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q=="
-    },
-    "vscode-languageserver-types": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
-      "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
+      "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q==",
+      "dev": true
     },
     "vscode-uri": {
       "version": "3.0.7",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "@vscode/l10n": "^0.0.10",
     "node-html-parser": "^6.1.5",
     "picomatch": "^2.3.1",
-    "vscode-languageserver-textdocument": "^1.0.8",
-    "vscode-languageserver-types": "^3.17.3",
+    "vscode-languageserver-protocol": "^3.17.1",
     "vscode-uri": "^3.0.7"
   },
   "devDependencies": {
@@ -35,7 +34,7 @@
     "mkdirp": "^1.0.4",
     "mocha": "^10.0.0",
     "typescript": "^5.1.3",
-    "vscode-languageserver": "^8.0.1"
+    "vscode-languageserver-textdocument": "^1.0.8"
   },
   "scripts": {
     "api-extractor": "mkdirp etc && npx api-extractor run --local",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { CancellationToken } from 'vscode-languageserver';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 import { getLsConfiguration, LsConfiguration } from './config';
 import { MdExtractLinkDefinitionCodeActionProvider } from './languageFeatures/codeActions/extractLinkDef';
@@ -50,7 +49,7 @@ export interface IMdLanguageService {
 	 *
 	 * Note that you must invoke {@link IMdLanguageService.resolveDocumentLink} on each link before executing the link.
 	 */
-	getDocumentLinks(document: ITextDocument, token: CancellationToken): Promise<lsp.DocumentLink[]>;
+	getDocumentLinks(document: ITextDocument, token: lsp.CancellationToken): Promise<lsp.DocumentLink[]>;
 
 	/**
 	 * Resolves a link from {@link IMdLanguageService.getDocumentLinks}.
@@ -59,7 +58,7 @@ export interface IMdLanguageService {
 	 *
 	 * @returns The resolved link or `undefined` if the passed in link should be used
 	 */
-	resolveDocumentLink(link: lsp.DocumentLink, token: CancellationToken): Promise<lsp.DocumentLink | undefined>;
+	resolveDocumentLink(link: lsp.DocumentLink, token: lsp.CancellationToken): Promise<lsp.DocumentLink | undefined>;
 
 	/**
 	 * Try to resolve the resources that a link in a markdown file points to.
@@ -69,14 +68,14 @@ export interface IMdLanguageService {
 	 * 
 	 * @returns The resolved target or undefined if it could not be resolved.
 	 */
-	resolveLinkTarget(linkText: string, fromResource: URI, token: CancellationToken): Promise<ResolvedDocumentLinkTarget | undefined>;
+	resolveLinkTarget(linkText: string, fromResource: URI, token: lsp.CancellationToken): Promise<ResolvedDocumentLinkTarget | undefined>;
 
 	/**
 	 * Get the symbols of a markdown file.
 	 *
 	 * @returns The headers and optionally also the link definitions in the file
 	 */
-	getDocumentSymbols(document: ITextDocument, options: { readonly includeLinkDefinitions?: boolean }, token: CancellationToken): Promise<lsp.DocumentSymbol[]>;
+	getDocumentSymbols(document: ITextDocument, options: { readonly includeLinkDefinitions?: boolean }, token: lsp.CancellationToken): Promise<lsp.DocumentSymbol[]>;
 
 	/**
 	 * Get the folding ranges of a markdown file.
@@ -87,43 +86,43 @@ export interface IMdLanguageService {
 	 * - Regions
 	 * - List and other block element
 	 */
-	getFoldingRanges(document: ITextDocument, token: CancellationToken): Promise<lsp.FoldingRange[]>;
+	getFoldingRanges(document: ITextDocument, token: lsp.CancellationToken): Promise<lsp.FoldingRange[]>;
 
 	/**
 	 * Get the selection ranges of a markdown file.
 	 */
-	getSelectionRanges(document: ITextDocument, positions: lsp.Position[], token: CancellationToken): Promise<lsp.SelectionRange[] | undefined>;
+	getSelectionRanges(document: ITextDocument, positions: lsp.Position[], token: lsp.CancellationToken): Promise<lsp.SelectionRange[] | undefined>;
 
 	/**
 	 * Get the symbols for all markdown files in the current workspace.
 	 *
 	 * Returns all headers in the workspace.
 	 */
-	getWorkspaceSymbols(query: string, token: CancellationToken): Promise<lsp.WorkspaceSymbol[]>;
+	getWorkspaceSymbols(query: string, token: lsp.CancellationToken): Promise<lsp.WorkspaceSymbol[]>;
 
 	/**
 	 * Get completions items at a given position in a markdown file.
 	 */
-	getCompletionItems(document: ITextDocument, position: lsp.Position, context: PathCompletionOptions, token: CancellationToken): Promise<lsp.CompletionItem[]>;
+	getCompletionItems(document: ITextDocument, position: lsp.Position, context: PathCompletionOptions, token: lsp.CancellationToken): Promise<lsp.CompletionItem[]>;
 
 	/**
 	 * Get the references to a symbol at the current location.
 	 *
 	 * Supports finding references to headers and links.
 	 */
-	getReferences(document: ITextDocument, position: lsp.Position, context: lsp.ReferenceContext, token: CancellationToken): Promise<lsp.Location[]>;
+	getReferences(document: ITextDocument, position: lsp.Position, context: lsp.ReferenceContext, token: lsp.CancellationToken): Promise<lsp.Location[]>;
 
 	/**
 	 * Get the references to a given file.
 	 */
-	getFileReferences(resource: URI, token: CancellationToken): Promise<lsp.Location[]>;
+	getFileReferences(resource: URI, token: lsp.CancellationToken): Promise<lsp.Location[]>;
 
 	/**
 	 * Get the definition of the symbol at the current location.
 	 *
 	 * Supports finding headers from fragments links or reference link definitions.
 	 */
-	getDefinition(document: ITextDocument, position: lsp.Position, token: CancellationToken): Promise<lsp.Definition | undefined>;
+	getDefinition(document: ITextDocument, position: lsp.Position, token: lsp.CancellationToken): Promise<lsp.Definition | undefined>;
 
 	/**
 	 * Organizes all link definitions in the file by grouping them to the bottom of the file, sorting them, and optionally
@@ -132,21 +131,21 @@ export interface IMdLanguageService {
 	 * @returns A set of text edits. May be empty if no edits are required (e.g. the definitions are already sorted at
 	 * the bottom of the file).
 	 */
-	organizeLinkDefinitions(document: ITextDocument, options: { readonly removeUnused?: boolean }, token: CancellationToken): Promise<lsp.TextEdit[]>;
+	organizeLinkDefinitions(document: ITextDocument, options: { readonly removeUnused?: boolean }, token: lsp.CancellationToken): Promise<lsp.TextEdit[]>;
 
 	/**
 	 * Prepare for showing rename UI.
 	 *
 	 * Indicates if rename is supported. If it is, returns the range of symbol being renamed as well as the placeholder to show to the user for the rename.
 	 */
-	prepareRename(document: ITextDocument, position: lsp.Position, token: CancellationToken): Promise<{ range: lsp.Range; placeholder: string } | undefined>;
+	prepareRename(document: ITextDocument, position: lsp.Position, token: lsp.CancellationToken): Promise<{ range: lsp.Range; placeholder: string } | undefined>;
 
 	/**
 	 * Get the edits for a rename operation.
 	 *
 	 * @returns A workspace edit that performs the rename or undefined if the rename cannot be performed.
 	 */
-	getRenameEdit(document: ITextDocument, position: lsp.Position, nameName: string, token: CancellationToken): Promise<lsp.WorkspaceEdit | undefined>;
+	getRenameEdit(document: ITextDocument, position: lsp.Position, nameName: string, token: lsp.CancellationToken): Promise<lsp.WorkspaceEdit | undefined>;
 
 	/**
 	 * Get the edits for a file rename. This update links to the renamed files as well as links within the renamed files.
@@ -157,19 +156,19 @@ export interface IMdLanguageService {
 	 *
 	 * @returns An object with a workspace edit that performs the rename and a list of old file uris that effected the edit. Returns undefined if the rename cannot be performed. 
 	 */
-	getRenameFilesInWorkspaceEdit(edits: readonly FileRename[], token: CancellationToken): Promise<{ participatingRenames: readonly FileRename[]; edit: lsp.WorkspaceEdit } | undefined>;
+	getRenameFilesInWorkspaceEdit(edits: readonly FileRename[], token: lsp.CancellationToken): Promise<{ participatingRenames: readonly FileRename[]; edit: lsp.WorkspaceEdit } | undefined>;
 
 	/**
 	 * Get code actions for a selection in a file.
 	 *
 	 * Returned code actions may be disabled.
 	 */
-	getCodeActions(document: ITextDocument, range: lsp.Range, context: lsp.CodeActionContext, token: CancellationToken): Promise<lsp.CodeAction[]>;
+	getCodeActions(document: ITextDocument, range: lsp.Range, context: lsp.CodeActionContext, token: lsp.CancellationToken): Promise<lsp.CodeAction[]>;
 
 	/**
 	 * Get document highlights for a position in the document.
 	 */
-	getDocumentHighlights(document: ITextDocument, position: lsp.Position, token: CancellationToken): Promise<lsp.DocumentHighlight[]>;
+	getDocumentHighlights(document: ITextDocument, position: lsp.Position, token: lsp.CancellationToken): Promise<lsp.DocumentHighlight[]>;
 
 	/**
 	 * Compute diagnostics for a given file.
@@ -177,7 +176,7 @@ export interface IMdLanguageService {
 	 * Note that this function is stateless and re-validates all links every time you make the request. Use {@link IMdLanguageService.createPullDiagnosticsManager}
 	 * to more efficiently get diagnostics.
 	 */
-	computeDiagnostics(doc: ITextDocument, options: DiagnosticOptions, token: CancellationToken): Promise<lsp.Diagnostic[]>;
+	computeDiagnostics(doc: ITextDocument, options: DiagnosticOptions, token: lsp.CancellationToken): Promise<lsp.Diagnostic[]>;
 
 	/**
 	 * Create a stateful object that is more efficient at computing diagnostics across repeated calls and workspace changes.
@@ -259,7 +258,7 @@ export function createLanguageService(init: LanguageServiceInitialization): IMdL
 		getWorkspaceSymbols: workspaceSymbolProvider.provideWorkspaceSymbols.bind(workspaceSymbolProvider),
 		getCompletionItems: pathCompletionProvider.provideCompletionItems.bind(pathCompletionProvider),
 		getReferences: referencesProvider.provideReferences.bind(referencesProvider),
-		getFileReferences: async (resource: URI, token: CancellationToken): Promise<lsp.Location[]> => {
+		getFileReferences: async (resource: URI, token: lsp.CancellationToken): Promise<lsp.Location[]> => {
 			return (await referencesProvider.getReferencesToFileInWorkspace(resource, token)).map(x => x.location);
 		},
 		getDefinition: definitionsProvider.provideDefinition.bind(definitionsProvider),
@@ -267,16 +266,16 @@ export function createLanguageService(init: LanguageServiceInitialization): IMdL
 		prepareRename: renameProvider.prepareRename.bind(renameProvider),
 		getRenameEdit: renameProvider.provideRenameEdits.bind(renameProvider),
 		getRenameFilesInWorkspaceEdit: fileRenameProvider.getRenameFilesInWorkspaceEdit.bind(fileRenameProvider),
-		getCodeActions: async (doc: ITextDocument, range: lsp.Range, context: lsp.CodeActionContext, token: CancellationToken): Promise<lsp.CodeAction[]> => {
+		getCodeActions: async (doc: ITextDocument, range: lsp.Range, context: lsp.CodeActionContext, token: lsp.CancellationToken): Promise<lsp.CodeAction[]> => {
 			return (await Promise.all([
 				extractCodeActionProvider.getActions(doc, range, context, token),
 				Array.from(removeLinkDefinitionActionProvider.getActions(doc, range, context)),
 			])).flat();
 		},
-		getDocumentHighlights: (document: ITextDocument, position: lsp.Position, token: CancellationToken): Promise<lsp.DocumentHighlight[]> => {
+		getDocumentHighlights: (document: ITextDocument, position: lsp.Position, token: lsp.CancellationToken): Promise<lsp.DocumentHighlight[]> => {
 			return documentHighlightProvider.getDocumentHighlights(document, position, token);
 		},
-		computeDiagnostics: async (doc: ITextDocument, options: DiagnosticOptions, token: CancellationToken): Promise<lsp.Diagnostic[]> => {
+		computeDiagnostics: async (doc: ITextDocument, options: DiagnosticOptions, token: lsp.CancellationToken): Promise<lsp.Diagnostic[]> => {
 			return (await diagnosticsComputer.compute(doc, options, token))?.diagnostics;
 		},
 		createPullDiagnosticsManager: () => {

--- a/src/languageFeatures/codeActions/extractLinkDef.ts
+++ b/src/languageFeatures/codeActions/extractLinkDef.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as l10n from '@vscode/l10n';
-import { CancellationToken } from 'vscode-languageserver';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { comparePosition, translatePosition } from '../../types/position';
 import { makeRange, rangeIntersects } from '../../types/range';
 import { getDocUri, getLine, ITextDocument } from '../../types/textDocument';
@@ -42,7 +41,7 @@ export class MdExtractLinkDefinitionCodeActionProvider {
 		this.#linkProvider = linkProvider;
 	}
 
-	async getActions(doc: ITextDocument, range: lsp.Range, context: lsp.CodeActionContext, token: CancellationToken): Promise<lsp.CodeAction[]> {
+	async getActions(doc: ITextDocument, range: lsp.Range, context: lsp.CodeActionContext, token: lsp.CancellationToken): Promise<lsp.CodeAction[]> {
 		if (!this.#isEnabled(context)) {
 			return [];
 		}

--- a/src/languageFeatures/codeActions/removeLinkDefinition.ts
+++ b/src/languageFeatures/codeActions/removeLinkDefinition.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as l10n from '@vscode/l10n';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { makeRange, rangeIntersects } from '../../types/range';
 import { getDocUri, ITextDocument } from '../../types/textDocument';
 import { WorkspaceEditBuilder } from '../../util/editBuilder';

--- a/src/languageFeatures/definitions.ts
+++ b/src/languageFeatures/definitions.ts
@@ -2,8 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { CancellationToken } from 'vscode-languageserver';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { LsConfiguration } from '../config';
 import { MdTableOfContentsProvider } from '../tableOfContents';
 import { rangeContains } from '../types/range';
@@ -31,7 +30,7 @@ export class MdDefinitionProvider {
 		this.#linkCache = linkCache;
 	}
 
-	async provideDefinition(document: ITextDocument, position: lsp.Position, token: CancellationToken): Promise<lsp.Definition | undefined> {
+	async provideDefinition(document: ITextDocument, position: lsp.Position, token: lsp.CancellationToken): Promise<lsp.Definition | undefined> {
 		const toc = await this.#tocProvider.getForDocument(document);
 		if (token.isCancellationRequested) {
 			return [];
@@ -45,7 +44,7 @@ export class MdDefinitionProvider {
 		return this.#getDefinitionOfLinkAtPosition(document, position, token);
 	}
 
-	async #getDefinitionOfLinkAtPosition(document: ITextDocument, position: lsp.Position, token: CancellationToken): Promise<lsp.Definition | undefined> {
+	async #getDefinitionOfLinkAtPosition(document: ITextDocument, position: lsp.Position, token: lsp.CancellationToken): Promise<lsp.Definition | undefined> {
 		const docLinks = (await this.#linkCache.getForDocs([document]))[0];
 
 		for (const link of docLinks) {
@@ -60,7 +59,7 @@ export class MdDefinitionProvider {
 		return undefined;
 	}
 
-	async #getDefinitionOfLink(sourceLink: MdLink, allLinksInFile: readonly MdLink[], token: CancellationToken): Promise<lsp.Definition | undefined> {
+	async #getDefinitionOfLink(sourceLink: MdLink, allLinksInFile: readonly MdLink[], token: lsp.CancellationToken): Promise<lsp.Definition | undefined> {
 		if (sourceLink.href.kind === HrefKind.Reference) {
 			return this.#getDefinitionOfRef(sourceLink.href.ref, allLinksInFile);
 		}

--- a/src/languageFeatures/documentHighlights.ts
+++ b/src/languageFeatures/documentHighlights.ts
@@ -3,8 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CancellationToken } from 'vscode-languageserver';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 import { LsConfiguration } from '../config';
 import { MdTableOfContentsProvider, TableOfContents, TocEntry } from '../tableOfContents';
@@ -31,7 +30,7 @@ export class MdDocumentHighlightProvider {
 		this.#linkProvider = linkProvider;
 	}
 
-	public async getDocumentHighlights(document: ITextDocument, position: lsp.Position, token: CancellationToken): Promise<lsp.DocumentHighlight[]> {
+	public async getDocumentHighlights(document: ITextDocument, position: lsp.Position, token: lsp.CancellationToken): Promise<lsp.DocumentHighlight[]> {
 		const toc = await this.#tocProvider.getForDocument(document);
 		if (token.isCancellationRequested) {
 			return [];

--- a/src/languageFeatures/documentLinks.ts
+++ b/src/languageFeatures/documentLinks.ts
@@ -5,8 +5,7 @@
 
 import * as l10n from '@vscode/l10n';
 import { HTMLElement, parse } from 'node-html-parser';
-import type { CancellationToken } from 'vscode-languageserver';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { URI, Utils } from 'vscode-uri';
 import { LsConfiguration } from '../config';
 import { ILogger, LogLevel } from '../logging';
@@ -443,7 +442,7 @@ export class MdLinkComputer {
 		this.#workspace = workspace;
 	}
 
-	public async getAllLinks(document: ITextDocument, token: CancellationToken): Promise<MdLink[]> {
+	public async getAllLinks(document: ITextDocument, token: lsp.CancellationToken): Promise<MdLink[]> {
 		const tokens = await this.#tokenizer.tokenize(document);
 		if (token.isCancellationRequested) {
 			return [];
@@ -829,7 +828,7 @@ export class MdLinkProvider extends Disposable {
 		return this.#linkCache.getForDocument(document);
 	}
 
-	public async provideDocumentLinks(document: ITextDocument, token: CancellationToken): Promise<lsp.DocumentLink[]> {
+	public async provideDocumentLinks(document: ITextDocument, token: lsp.CancellationToken): Promise<lsp.DocumentLink[]> {
 		const { links, definitions } = await this.getLinks(document);
 		if (token.isCancellationRequested) {
 			return [];
@@ -838,7 +837,7 @@ export class MdLinkProvider extends Disposable {
 		return coalesce(links.map(data => this.#toValidDocumentLink(data, definitions)));
 	}
 
-	public async resolveDocumentLink(link: lsp.DocumentLink, token: CancellationToken): Promise<lsp.DocumentLink | undefined> {
+	public async resolveDocumentLink(link: lsp.DocumentLink, token: lsp.CancellationToken): Promise<lsp.DocumentLink | undefined> {
 		const href = this.#reviveLinkHrefData(link);
 		if (!href) {
 			return undefined;
@@ -864,7 +863,7 @@ export class MdLinkProvider extends Disposable {
 		return link;
 	}
 
-	public async resolveLinkTarget(linkText: string, sourceDoc: URI, token: CancellationToken): Promise<ResolvedDocumentLinkTarget | undefined> {
+	public async resolveLinkTarget(linkText: string, sourceDoc: URI, token: lsp.CancellationToken): Promise<ResolvedDocumentLinkTarget | undefined> {
 		const href = createHref(sourceDoc, linkText, this.#workspace);
 		if (href?.kind !== HrefKind.Internal) {
 			return undefined;
@@ -878,7 +877,7 @@ export class MdLinkProvider extends Disposable {
 		return this.#resolveInternalLinkTarget(resolved.resource, resolved.linkFragment, token);
 	}
 
-	async #resolveInternalLinkTarget(linkPath: URI, linkFragment: string, token: CancellationToken): Promise<ResolvedDocumentLinkTarget> {
+	async #resolveInternalLinkTarget(linkPath: URI, linkFragment: string, token: lsp.CancellationToken): Promise<ResolvedDocumentLinkTarget> {
 		let target = linkPath;
 
 		// If there's a containing document, don't bother with trying to resolve the

--- a/src/languageFeatures/documentSymbols.ts
+++ b/src/languageFeatures/documentSymbols.ts
@@ -3,8 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CancellationToken } from 'vscode-languageserver';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { ILogger, LogLevel } from '../logging';
 import { MdTableOfContentsProvider, TableOfContents, TocEntry } from '../tableOfContents';
 import { isBefore } from '../types/position';
@@ -39,7 +38,7 @@ export class MdDocumentSymbolProvider {
 		this.#logger = logger;
 	}
 
-	public async provideDocumentSymbols(document: ITextDocument, options: ProvideDocumentSymbolOptions, token: CancellationToken): Promise<lsp.DocumentSymbol[]> {
+	public async provideDocumentSymbols(document: ITextDocument, options: ProvideDocumentSymbolOptions, token: lsp.CancellationToken): Promise<lsp.DocumentSymbol[]> {
 		this.#logger.log(LogLevel.Debug, 'DocumentSymbolProvider.provideDocumentSymbols', { document: document.uri, version: document.version });
 
 		const linkSymbols = await (options.includeLinkDefinitions ? this.#provideLinkDefinitionSymbols(document, token) : []);
@@ -69,7 +68,7 @@ export class MdDocumentSymbolProvider {
 		return root.children;
 	}
 
-	async #provideLinkDefinitionSymbols(document: ITextDocument, token: CancellationToken): Promise<lsp.DocumentSymbol[]> {
+	async #provideLinkDefinitionSymbols(document: ITextDocument, token: lsp.CancellationToken): Promise<lsp.DocumentSymbol[]> {
 		const { links } = await this.#linkProvider.getLinks(document);
 		if (token.isCancellationRequested) {
 			return [];

--- a/src/languageFeatures/fileRename.ts
+++ b/src/languageFeatures/fileRename.ts
@@ -3,8 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as path from 'path';
-import { CancellationToken } from 'vscode-languageserver';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { URI, Utils } from 'vscode-uri';
 import { LsConfiguration, PreferredMdPathExtensionStyle, isExcludedPath } from '../config';
 import { ITextDocument, getDocUri } from '../types/textDocument';
@@ -50,7 +49,7 @@ export class MdFileRenameProvider extends Disposable {
 		this.#referencesProvider = referencesProvider;
 	}
 
-	async getRenameFilesInWorkspaceEdit(edits: readonly FileRename[], token: CancellationToken): Promise<FileRenameResponse | undefined> {
+	async getRenameFilesInWorkspaceEdit(edits: readonly FileRename[], token: lsp.CancellationToken): Promise<FileRenameResponse | undefined> {
 		const builder = new WorkspaceEditBuilder();
 		const participatingRenames: FileRename[] = [];
 
@@ -72,7 +71,7 @@ export class MdFileRenameProvider extends Disposable {
 		return { participatingRenames, edit: builder.getEdit() };
 	}
 
-	async #addSingleFileRenameEdits(edit: FileRename, allEdits: readonly FileRename[], builder: WorkspaceEditBuilder, token: CancellationToken): Promise<boolean> {
+	async #addSingleFileRenameEdits(edit: FileRename, allEdits: readonly FileRename[], builder: WorkspaceEditBuilder, token: lsp.CancellationToken): Promise<boolean> {
 		let didParticipate = false;
 
 		// Update all references to the file
@@ -92,7 +91,7 @@ export class MdFileRenameProvider extends Disposable {
 		return didParticipate;
 	}
 
-	async #addDirectoryRenameEdits(edit: FileRename, builder: WorkspaceEditBuilder, token: CancellationToken): Promise<boolean> {
+	async #addDirectoryRenameEdits(edit: FileRename, builder: WorkspaceEditBuilder, token: lsp.CancellationToken): Promise<boolean> {
 		// First update every link that points to something in the moved dir
 		const allLinksInWorkspace = await this.#linkCache.entries();
 		if (token.isCancellationRequested) {
@@ -217,7 +216,7 @@ export class MdFileRenameProvider extends Disposable {
 	/**
 	 * Update links across the workspace for the new file name
 	 */
-	async #addEditsForReferencesToFile(edit: FileRename, builder: WorkspaceEditBuilder, token: CancellationToken): Promise<boolean> {
+	async #addEditsForReferencesToFile(edit: FileRename, builder: WorkspaceEditBuilder, token: lsp.CancellationToken): Promise<boolean> {
 		if (isExcludedPath(this.#config, edit.newUri)) {
 			return false;
 		}

--- a/src/languageFeatures/folding.ts
+++ b/src/languageFeatures/folding.ts
@@ -3,8 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CancellationToken } from 'vscode-languageserver';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { ILogger, LogLevel } from '../logging';
 import { IMdParser, Token, TokenWithMap } from '../parser';
 import { MdTableOfContentsProvider } from '../tableOfContents';
@@ -34,7 +33,7 @@ export class MdFoldingProvider {
 		this.#logger = logger;
 	}
 
-	public async provideFoldingRanges(document: ITextDocument, token: CancellationToken): Promise<lsp.FoldingRange[]> {
+	public async provideFoldingRanges(document: ITextDocument, token: lsp.CancellationToken): Promise<lsp.FoldingRange[]> {
 		this.#logger.log(LogLevel.Debug, 'MdFoldingProvider.provideFoldingRanges', { document: document.uri, version: document.version });
 
 		const foldables = await Promise.all([
@@ -46,7 +45,7 @@ export class MdFoldingProvider {
 		return result.length > rangeLimit ? result.slice(0, rangeLimit) : result;
 	}
 
-	async #getRegions(document: ITextDocument, token: CancellationToken): Promise<lsp.FoldingRange[]> {
+	async #getRegions(document: ITextDocument, token: lsp.CancellationToken): Promise<lsp.FoldingRange[]> {
 		const tokens = await this.#parser.tokenize(document);
 		if (token.isCancellationRequested) {
 			return [];
@@ -71,7 +70,7 @@ export class MdFoldingProvider {
 		}
 	}
 
-	async #getHeaderFoldingRanges(document: ITextDocument, token: CancellationToken): Promise<lsp.FoldingRange[]> {
+	async #getHeaderFoldingRanges(document: ITextDocument, token: lsp.CancellationToken): Promise<lsp.FoldingRange[]> {
 		const toc = await this.#tocProvider.getForDocument(document);
 		if (token.isCancellationRequested) {
 			return [];
@@ -86,7 +85,7 @@ export class MdFoldingProvider {
 		});
 	}
 
-	async #getBlockFoldingRanges(document: ITextDocument, token: CancellationToken): Promise<lsp.FoldingRange[]> {
+	async #getBlockFoldingRanges(document: ITextDocument, token: lsp.CancellationToken): Promise<lsp.FoldingRange[]> {
 		const tokens = await this.#parser.tokenize(document);
 		if (token.isCancellationRequested) {
 			return [];

--- a/src/languageFeatures/organizeLinkDefs.ts
+++ b/src/languageFeatures/organizeLinkDefs.ts
@@ -3,8 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CancellationToken } from 'vscode-languageserver';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { makeRange } from '../types/range';
 import { getLine, ITextDocument } from '../types/textDocument';
 import { isEmptyOrWhitespace } from '../util/string';
@@ -18,7 +17,7 @@ export class MdOrganizeLinkDefinitionProvider {
 		this.#linkProvider = linkProvider;
 	}
 
-	async getOrganizeLinkDefinitionEdits(doc: ITextDocument, options: { readonly removeUnused?: boolean }, token: CancellationToken): Promise<lsp.TextEdit[]> {
+	async getOrganizeLinkDefinitionEdits(doc: ITextDocument, options: { readonly removeUnused?: boolean }, token: lsp.CancellationToken): Promise<lsp.TextEdit[]> {
 		const links = await this.#linkProvider.getLinks(doc);
 		if (token.isCancellationRequested) {
 			return [];

--- a/src/languageFeatures/pathCompletions.ts
+++ b/src/languageFeatures/pathCompletions.ts
@@ -6,7 +6,7 @@
 import * as l10n from '@vscode/l10n';
 import { dirname, extname, resolve } from 'path';
 import type { CancellationToken, CompletionContext } from 'vscode-languageserver-protocol';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { URI, Utils } from 'vscode-uri';
 import { LsConfiguration, isExcludedPath } from '../config';
 import { IMdParser } from '../parser';

--- a/src/languageFeatures/references.ts
+++ b/src/languageFeatures/references.ts
@@ -2,8 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { CancellationToken } from 'vscode-languageserver';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 import { LsConfiguration } from '../config';
 import { ILogger, LogLevel } from '../logging';
@@ -98,14 +97,14 @@ export class MdReferencesProvider extends Disposable {
 		this.#logger = logger;
 	}
 
-	async provideReferences(document: ITextDocument, position: lsp.Position, context: lsp.ReferenceContext, token: CancellationToken): Promise<lsp.Location[]> {
+	async provideReferences(document: ITextDocument, position: lsp.Position, context: lsp.ReferenceContext, token: lsp.CancellationToken): Promise<lsp.Location[]> {
 		const allRefs = await this.getReferencesAtPosition(document, position, token);
 		return allRefs
 			.filter(ref => context.includeDeclaration || !ref.isDefinition)
 			.map(ref => ref.location);
 	}
 
-	public async getReferencesAtPosition(document: ITextDocument, position: lsp.Position, token: CancellationToken): Promise<MdReference[]> {
+	public async getReferencesAtPosition(document: ITextDocument, position: lsp.Position, token: lsp.CancellationToken): Promise<MdReference[]> {
 		this.#logger.log(LogLevel.Debug, 'ReferencesProvider.getReferencesAtPosition', { document: document.uri, version: document.version });
 
 		const toc = await this.#tocProvider.getForDocument(document);
@@ -121,7 +120,7 @@ export class MdReferencesProvider extends Disposable {
 		}
 	}
 
-	public async getReferencesToFileInWorkspace(resource: URI, token: CancellationToken): Promise<MdReference[]> {
+	public async getReferencesToFileInWorkspace(resource: URI, token: lsp.CancellationToken): Promise<MdReference[]> {
 		this.#logger.log(LogLevel.Debug, 'ReferencesProvider.getAllReferencesToFileInWorkspace', { resource });
 
 		const allLinksInWorkspace = await this.#getAllLinksInWorkspace();
@@ -132,7 +131,7 @@ export class MdReferencesProvider extends Disposable {
 		return Array.from(this.#findLinksToFile(resource, allLinksInWorkspace, undefined));
 	}
 
-	async #getReferencesToHeader(document: ITextDocument, header: TocEntry, token: CancellationToken): Promise<MdReference[]> {
+	async #getReferencesToHeader(document: ITextDocument, header: TocEntry, token: lsp.CancellationToken): Promise<MdReference[]> {
 		const links = await this.#getAllLinksInWorkspace();
 		if (token.isCancellationRequested) {
 			return [];
@@ -167,7 +166,7 @@ export class MdReferencesProvider extends Disposable {
 		return references;
 	}
 
-	async #getReferencesToLinkAtPosition(document: ITextDocument, position: lsp.Position, token: CancellationToken): Promise<MdReference[]> {
+	async #getReferencesToLinkAtPosition(document: ITextDocument, position: lsp.Position, token: lsp.CancellationToken): Promise<MdReference[]> {
 		const docLinks = (await this.#linkCache.getForDocs([document]))[0];
 		if (token.isCancellationRequested) {
 			return [];
@@ -191,7 +190,7 @@ export class MdReferencesProvider extends Disposable {
 		return [];
 	}
 
-	async #getReferencesToLink(docLinks: Iterable<MdLink>, sourceLink: MdLink, triggerPosition: lsp.Position, token: CancellationToken): Promise<MdReference[]> {
+	async #getReferencesToLink(docLinks: Iterable<MdLink>, sourceLink: MdLink, triggerPosition: lsp.Position, token: lsp.CancellationToken): Promise<MdReference[]> {
 		if (sourceLink.href.kind === HrefKind.Reference) {
 			return Array.from(this.#getReferencesToLinkReference(docLinks, sourceLink.href.ref, { resource: sourceLink.source.resource, range: sourceLink.source.hrefRange }));
 		}

--- a/src/languageFeatures/rename.ts
+++ b/src/languageFeatures/rename.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as l10n from '@vscode/l10n';
 import * as path from 'path';
-import { CancellationToken } from 'vscode-languageserver';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { URI, Utils } from 'vscode-uri';
 import { LsConfiguration, defaultMarkdownFileExtension } from '../config';
 import { ILogger, LogLevel } from '../logging';
@@ -68,7 +67,7 @@ export class MdRenameProvider extends Disposable {
 		this.#logger = logger;
 	}
 
-	public async prepareRename(document: ITextDocument, position: lsp.Position, token: CancellationToken): Promise<undefined | { range: lsp.Range; placeholder: string }> {
+	public async prepareRename(document: ITextDocument, position: lsp.Position, token: lsp.CancellationToken): Promise<undefined | { range: lsp.Range; placeholder: string }> {
 		this.#logger.log(LogLevel.Debug, 'RenameProvider.prepareRename', { document: document.uri, version: document.version });
 
 		const allRefsInfo = await this.#getAllReferences(document, position, token);
@@ -120,7 +119,7 @@ export class MdRenameProvider extends Disposable {
 		return references.find(ref => ref.isDefinition && ref.kind === MdReferenceKind.Header) as MdHeaderReference | undefined;
 	}
 
-	public async provideRenameEdits(document: ITextDocument, position: lsp.Position, newName: string, token: CancellationToken): Promise<lsp.WorkspaceEdit | undefined> {
+	public async provideRenameEdits(document: ITextDocument, position: lsp.Position, newName: string, token: lsp.CancellationToken): Promise<lsp.WorkspaceEdit | undefined> {
 		this.#logger.log(LogLevel.Debug, 'RenameProvider.provideRenameEdits', { document: document.uri, version: document.version });
 
 		const allRefsInfo = await this.#getAllReferences(document, position, token);
@@ -145,7 +144,7 @@ export class MdRenameProvider extends Disposable {
 		return undefined;
 	}
 
-	async #renameFilePath(triggerDocument: URI, triggerHref: InternalHref, allRefsInfo: MdReferencesResponse, newName: string, token: CancellationToken): Promise<lsp.WorkspaceEdit> {
+	async #renameFilePath(triggerDocument: URI, triggerHref: InternalHref, allRefsInfo: MdReferencesResponse, newName: string, token: lsp.CancellationToken): Promise<lsp.WorkspaceEdit> {
 		const builder = new WorkspaceEditBuilder();
 
 		const targetUri = await statLinkToMarkdownFile(this.#configuration, this.#workspace, triggerHref.path) ?? triggerHref.path;
@@ -236,7 +235,7 @@ export class MdRenameProvider extends Disposable {
 		return builder.getEdit();
 	}
 
-	async #getAllReferences(document: ITextDocument, position: lsp.Position, token: CancellationToken): Promise<MdReferencesResponse | undefined> {
+	async #getAllReferences(document: ITextDocument, position: lsp.Position, token: lsp.CancellationToken): Promise<MdReferencesResponse | undefined> {
 		const version = document.version;
 
 		if (this.#cachedRefs
@@ -321,5 +320,3 @@ export function getLinkRenameEdit(link: MdLink, newPathText: string): lsp.TextEd
 
 	return { range: linkRange, newText: newPathText };
 }
-
-

--- a/src/languageFeatures/workspaceSymbols.ts
+++ b/src/languageFeatures/workspaceSymbols.ts
@@ -3,8 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CancellationToken } from 'vscode-languageserver';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { ITextDocument } from '../types/textDocument';
 import { Disposable } from '../util/dispose';
 import { IWorkspace } from '../workspace';
@@ -27,7 +26,7 @@ export class MdWorkspaceSymbolProvider extends Disposable {
 		this.#cache = this._register(new MdWorkspaceInfoCache(workspace, (doc, token) => this.provideDocumentSymbolInformation(doc, token)));
 	}
 
-	public async provideWorkspaceSymbols(query: string, token: CancellationToken): Promise<lsp.WorkspaceSymbol[]> {
+	public async provideWorkspaceSymbols(query: string, token: lsp.CancellationToken): Promise<lsp.WorkspaceSymbol[]> {
 		const allSymbols = await this.#cache.values();
 		if (token.isCancellationRequested) {
 			return [];
@@ -39,7 +38,7 @@ export class MdWorkspaceSymbolProvider extends Disposable {
 		});
 	}
 
-	public async provideDocumentSymbolInformation(document: ITextDocument, token: CancellationToken): Promise<lsp.SymbolInformation[]> {
+	public async provideDocumentSymbolInformation(document: ITextDocument, token: lsp.CancellationToken): Promise<lsp.SymbolInformation[]> {
 		const docSymbols = await this.#symbolProvider.provideDocumentSymbols(document, {}, token);
 		if (token.isCancellationRequested) {
 			return [];

--- a/src/tableOfContents.ts
+++ b/src/tableOfContents.ts
@@ -3,8 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CancellationToken } from 'vscode-languageserver';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 import { ILogger, LogLevel } from './logging';
 import { IMdParser, Token } from './parser';
@@ -67,12 +66,12 @@ export interface TocEntry {
 
 export class TableOfContents {
 
-	public static async create(parser: IMdParser, document: ITextDocument, token: CancellationToken): Promise<TableOfContents> {
+	public static async create(parser: IMdParser, document: ITextDocument, token: lsp.CancellationToken): Promise<TableOfContents> {
 		const entries = await this.#buildToc(parser, document, token);
 		return new TableOfContents(entries, parser.slugifier);
 	}
 
-	public static async createForContainingDoc(parser: IMdParser, workspace: IWorkspace, document: ITextDocument, token: CancellationToken): Promise<TableOfContents> {
+	public static async createForContainingDoc(parser: IMdParser, workspace: IWorkspace, document: ITextDocument, token: lsp.CancellationToken): Promise<TableOfContents> {
 		const context = workspace.getContainingDocument?.(getDocUri(document));
 		if (context) {
 			const entries = (await Promise.all(Array.from(context.children, async cell => {
@@ -88,7 +87,7 @@ export class TableOfContents {
 		return this.create(parser, document, token);
 	}
 
-	static async #buildToc(parser: IMdParser, document: ITextDocument, token: CancellationToken): Promise<TocEntry[]> {
+	static async #buildToc(parser: IMdParser, document: ITextDocument, token: lsp.CancellationToken): Promise<TocEntry[]> {
 		const docUri = getDocUri(document);
 
 		const toc: TocEntry[] = [];
@@ -266,7 +265,7 @@ export class MdTableOfContentsProvider extends Disposable {
 		return this.#cache.getForDocument(doc);
 	}
 
-	public getForContainingDoc(doc: ITextDocument, token: CancellationToken): Promise<TableOfContents> {
+	public getForContainingDoc(doc: ITextDocument, token: lsp.CancellationToken): Promise<TableOfContents> {
 		return TableOfContents.createForContainingDoc(this.#parser, this.#workspace, doc, token);
 	}
 }

--- a/src/test/codeActions/extractLinkDef.test.ts
+++ b/src/test/codeActions/extractLinkDef.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as assert from 'assert';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { MdLinkProvider } from '../../languageFeatures/documentLinks';
 import { MdExtractLinkDefinitionCodeActionProvider } from '../../languageFeatures/codeActions/extractLinkDef';
 import { MdTableOfContentsProvider } from '../../tableOfContents';

--- a/src/test/codeActions/removeLinkDefinition.test.ts
+++ b/src/test/codeActions/removeLinkDefinition.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as assert from 'assert';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { getLsConfiguration } from '../../config';
 import { MdRemoveLinkDefinitionCodeActionProvider } from '../../languageFeatures/codeActions/removeLinkDefinition';
 import { DiagnosticComputer } from '../../languageFeatures/diagnostics';
@@ -170,5 +170,3 @@ suite('Remove link definition code action', () => {
 		));
 	}));
 });
-
-

--- a/src/test/definition.test.ts
+++ b/src/test/definition.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 import { getLsConfiguration } from '../config';
 import { MdDefinitionProvider } from '../languageFeatures/definitions';

--- a/src/test/diagnostic.test.ts
+++ b/src/test/diagnostic.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { getLsConfiguration } from '../config';
 import { DiagnosticComputer, DiagnosticLevel, DiagnosticOptions, DiagnosticsManager } from '../languageFeatures/diagnostics';
 import { MdLinkProvider } from '../languageFeatures/documentLinks';

--- a/src/test/documentHighlights.test.ts
+++ b/src/test/documentHighlights.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { getLsConfiguration } from '../config';
 import { MdDocumentHighlightProvider } from '../languageFeatures/documentHighlights';
 import { MdLinkProvider } from '../languageFeatures/documentLinks';

--- a/src/test/documentLinks.test.ts
+++ b/src/test/documentLinks.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 import { getLsConfiguration } from '../config';
 import { InternalHref, MdLink, MdLinkComputer, MdLinkProvider } from '../languageFeatures/documentLinks';

--- a/src/test/documentSymbols.test.ts
+++ b/src/test/documentSymbols.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { getLsConfiguration } from '../config';
 import { MdLinkProvider } from '../languageFeatures/documentLinks';
 import { MdDocumentSymbolProvider, ProvideDocumentSymbolOptions } from '../languageFeatures/documentSymbols';
@@ -225,4 +225,3 @@ suite('Document symbols', () => {
 		]);
 	}));
 });
-

--- a/src/test/fileRename.test.ts
+++ b/src/test/fileRename.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 import { getLsConfiguration, LsConfiguration, PreferredMdPathExtensionStyle } from '../config';
 import { createWorkspaceLinkCache } from '../languageFeatures/documentLinks';

--- a/src/test/folding.test.ts
+++ b/src/test/folding.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 import { MdFoldingProvider } from '../languageFeatures/folding';
 import { MdTableOfContentsProvider } from '../tableOfContents';

--- a/src/test/inMemoryDocument.ts
+++ b/src/test/inMemoryDocument.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 import { ITextDocument } from '../types/textDocument';
 

--- a/src/test/inMemoryWorkspace.ts
+++ b/src/test/inMemoryWorkspace.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert';
 import * as path from 'path';
-import { Emitter } from 'vscode-languageserver';
+import { Emitter } from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 import { getDocUri, ITextDocument } from '../types/textDocument';
 import { Disposable } from '../util/dispose';

--- a/src/test/organizeLinkDef.test.ts
+++ b/src/test/organizeLinkDef.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as assert from 'assert';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { getLsConfiguration } from '../config';
 import { MdLinkProvider } from '../languageFeatures/documentLinks';
 import { MdOrganizeLinkDefinitionProvider } from '../languageFeatures/organizeLinkDefs';

--- a/src/test/pathCompletion.test.ts
+++ b/src/test/pathCompletion.test.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import * as ls from 'vscode-languageserver';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 import { getLsConfiguration, LsConfiguration, PreferredMdPathExtensionStyle } from '../config';
 import { MdLinkProvider } from '../languageFeatures/documentLinks';
@@ -32,7 +31,7 @@ async function getCompletionsAtCursor(store: DisposableStore, doc: InMemoryDocum
 
 	const completions = await provider.provideCompletionItems(doc, cursorPositions[0], {
 		triggerCharacter: undefined,
-		triggerKind: ls.CompletionTriggerKind.Invoked,
+		triggerKind: lsp.CompletionTriggerKind.Invoked,
 		...context
 	}, noopToken);
 

--- a/src/test/references.test.ts
+++ b/src/test/references.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 import { getLsConfiguration } from '../config';
 import { createWorkspaceLinkCache } from '../languageFeatures/documentLinks';
@@ -707,4 +707,3 @@ suite('References', () => {
 		}));
 	});
 });
-

--- a/src/test/rename.test.ts
+++ b/src/test/rename.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 import { getLsConfiguration } from '../config';
 import { createWorkspaceLinkCache } from '../languageFeatures/documentLinks';

--- a/src/test/smartSelect.test.ts
+++ b/src/test/smartSelect.test.ts
@@ -4,9 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { CancellationTokenSource } from 'vscode-languageserver';
-import * as lsp from 'vscode-languageserver-types';
-import { Position } from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 import { MdSelectionRangeProvider } from '../languageFeatures/smartSelect';
 import { MdTableOfContentsProvider } from '../tableOfContents';
@@ -707,11 +705,11 @@ function assertLineNumbersEqual(selectionRange: lsp.SelectionRange, startLine: n
 	assert.strictEqual(selectionRange.range.end.line, endLine, `failed on end line ${message}`);
 }
 
-function getSelectionRangesForDocument(contents: string, pos?: Position[]): Promise<lsp.SelectionRange[] | undefined> {
+function getSelectionRangesForDocument(contents: string, pos?: lsp.Position[]): Promise<lsp.SelectionRange[] | undefined> {
 	const doc = new InMemoryDocument(testFileName, contents);
 	const workspace = new InMemoryWorkspace([doc]);
 	const engine = createNewMarkdownEngine();
 	const provider = new MdSelectionRangeProvider(engine, new MdTableOfContentsProvider(engine, workspace, nulLogger), nulLogger);
 	const positions = pos ? pos : getCursorPositions(contents, doc);
-	return provider.provideSelectionRanges(doc, positions, new CancellationTokenSource().token);
+	return provider.provideSelectionRanges(doc, positions, new lsp.CancellationTokenSource().token);
 }

--- a/src/test/util.ts
+++ b/src/test/util.ts
@@ -5,8 +5,7 @@
 
 import * as assert from 'assert';
 import * as os from 'os';
-import * as lsp from 'vscode-languageserver-types';
-import { Position, Range } from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import * as URI from 'vscode-uri';
 import { DiagnosticLevel, DiagnosticOptions } from '../languageFeatures/diagnostics';
 import { DisposableStore } from '../util/dispose';
@@ -20,7 +19,7 @@ export function workspacePath(...segments: string[]): URI.URI {
 	return URI.Utils.joinPath(workspaceRoot, ...segments);
 }
 
-export function assertRangeEqual(expected: Range, actual: Range, message?: string) {
+export function assertRangeEqual(expected: lsp.Range, actual: lsp.Range, message?: string) {
 	assert.strictEqual(expected.start.line, actual.start.line, `${message || ''}. Range start line not equal`);
 	assert.strictEqual(expected.start.character, actual.start.character, `${message || ''}. Range start character not equal`);
 	assert.strictEqual(expected.end.line, actual.end.line, `${message || ''}. Range end line not equal`);
@@ -40,8 +39,8 @@ export function withStore<R>(fn: (this: Mocha.Context, store: DisposableStore) =
 
 export const CURSOR = '$$CURSOR$$';
 
-export function getCursorPositions(contents: string, doc: InMemoryDocument): Position[] {
-	const positions: Position[] = [];
+export function getCursorPositions(contents: string, doc: InMemoryDocument): lsp.Position[] {
+	const positions: lsp.Position[] = [];
 	let index = 0;
 	let wordLength = 0;
 	while (index !== -1) {

--- a/src/test/workspaceSymbol.test.ts
+++ b/src/test/workspaceSymbol.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as assert from 'assert';
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { IWorkspace } from '..';
 import { getLsConfiguration } from '../config';
 import { MdLinkProvider } from '../languageFeatures/documentLinks';

--- a/src/types/position.ts
+++ b/src/types/position.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Position } from 'vscode-languageserver-types';
+import { Position } from 'vscode-languageserver-protocol';
 
 export function arePositionsEqual(a: Position, b: Position): boolean {
 	return a.line === b.line && a.character === b.character;

--- a/src/types/range.ts
+++ b/src/types/range.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Position, Range } from 'vscode-languageserver-types';
+import { Position, Range } from 'vscode-languageserver-protocol';
 import { arePositionsEqual, isBefore, isPosition } from './position';
 
 export function isRange(thing: any): thing is Range {

--- a/src/types/textDocument.ts
+++ b/src/types/textDocument.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Position, Range } from 'vscode-languageserver-types';
+import { Position, Range } from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 import { makeRange } from './range';
 

--- a/src/util/cancellation.ts
+++ b/src/util/cancellation.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CancellationToken, Emitter } from 'vscode-languageserver';
+import { CancellationToken, Emitter } from 'vscode-languageserver-protocol';
 
 export const noopToken: CancellationToken = new class implements CancellationToken {
 	readonly #onCancellationRequestedEmitter = new Emitter<void>();

--- a/src/util/editBuilder.ts
+++ b/src/util/editBuilder.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as lsp from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 
 export class WorkspaceEditBuilder {

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Event } from 'vscode-languageserver';
+import { Event } from 'vscode-languageserver-protocol';
 import { URI, Utils } from 'vscode-uri';
 import { defaultMarkdownFileExtension, LsConfiguration } from './config';
 import { ITextDocument } from './types/textDocument';

--- a/src/workspaceCache.ts
+++ b/src/workspaceCache.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CancellationToken, CancellationTokenSource } from 'vscode-languageserver';
+import { CancellationToken, CancellationTokenSource } from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 import { getDocUri, ITextDocument } from './types/textDocument';
 import { Disposable } from './util/dispose';


### PR DESCRIPTION
This package was importing code from `vscode-languageserver`. However, it doesn’t specify `vscode-languageserver` as a dependency. All imports used, were just re-exports from the `vscode-languageserver-protocol` package. It was also importing code from the `vscode-languageserver-types` package.

This changes all imports from `vscode-languageserver` and `vscode-languageserver-types` to `vscode-languageserver-protocol` imports, and adds this mising dependency.

Also the `vscode-languageserver-textdocument` dependency was moved into `devDependencies`, because it’s only used in a test and in the example.