### PR TITLE
Fix URI equality checks

### DIFF
--- a/src/languageFeatures/codeActions/extractLinkDef.ts
+++ b/src/languageFeatures/codeActions/extractLinkDef.ts
@@ -13,6 +13,7 @@ import { WorkspaceEditBuilder } from '../../util/editBuilder';
 import { MdDocumentLinksInfo, MdLinkProvider } from '../documentLinks';
 import { getExistingDefinitionBlock } from '../organizeLinkDefs';
 import { codeActionKindContains } from './util';
+import { isSameResource } from '../../util/path';
 
 export class MdExtractLinkDefinitionCodeActionProvider {
 
@@ -123,11 +124,11 @@ export class MdExtractLinkDefinitionCodeActionProvider {
 
 	#matchesHref(href: InternalHref | ExternalHref, link: MdLink): boolean {
 		if (link.href.kind === HrefKind.External && href.kind === HrefKind.External) {
-			return link.href.uri.toString() === href.uri.toString();
+			return isSameResource(link.href.uri, href.uri);
 		}
 
 		if (link.href.kind === HrefKind.Internal && href.kind === HrefKind.Internal) {
-			return link.href.path.toString() === href.path.toString() && link.href.fragment === href.fragment;
+			return isSameResource(link.href.path, href.path) && link.href.fragment === href.fragment;
 		}
 
 		return false;

--- a/src/languageFeatures/diagnostics.ts
+++ b/src/languageFeatures/diagnostics.ts
@@ -16,7 +16,7 @@ import { modifyRange } from '../types/range';
 import { getDocUri, ITextDocument } from '../types/textDocument';
 import { Disposable, IDisposable } from '../util/dispose';
 import { Limiter } from '../util/limiter';
-import { looksLikeMarkdownUri, parseLocationInfoFromFragment } from '../util/path';
+import { isSameResource, looksLikeMarkdownUri, parseLocationInfoFromFragment } from '../util/path';
 import { ResourceMap } from '../util/resourceMap';
 import { FileStat, IWorkspace, IWorkspaceWithWatching, statLinkToMarkdownFile } from '../workspace';
 import { MdLinkProvider } from './documentLinks';
@@ -203,7 +203,7 @@ export class DiagnosticComputer {
 		])).flat();
 
 		this.#logger.log(LogLevel.Trace, 'DiagnosticComputer.compute finished', { document: doc.uri, version: doc.version, diagnostics });
-		
+
 		return {
 			links: links,
 			statCache,
@@ -227,7 +227,7 @@ export class DiagnosticComputer {
 
 			if (link.href.kind === HrefKind.Internal
 				&& link.source.hrefText.startsWith('#')
-				&& link.href.path.toString() === doc.uri.toString()
+				&& isSameResource(link.href.path, getDocUri(doc))
 				&& link.href.fragment
 				&& !toc.lookup(link.href.fragment)
 			) {
@@ -618,7 +618,7 @@ export class DiagnosticsManager extends Disposable implements IPullDiagnosticsMa
 
 		this._register(this.#linkWatcher.onDidChangeLinkedToFile(e => {
 			logger.log(LogLevel.Trace, 'DiagnosticsManager.onDidChangeLinkedToFile', { resource: e.changedResource });
-			
+
 			this.#onLinkedToFileChanged.fire({
 				changedResource: e.changedResource,
 				linkingResources: Array.from(e.linkingFiles),

--- a/src/languageFeatures/fileRename.ts
+++ b/src/languageFeatures/fileRename.ts
@@ -10,7 +10,7 @@ import { HrefKind, MdLink } from '../types/documentLink';
 import { ITextDocument, getDocUri } from '../types/textDocument';
 import { WorkspaceEditBuilder } from '../util/editBuilder';
 import { removeNewUriExtIfNeeded, resolveInternalDocumentLink } from '../util/mdLinks';
-import { isParentDir, looksLikeMarkdownUri } from '../util/path';
+import { isParentDir, isSameResource, looksLikeMarkdownUri } from '../util/path';
 import { IWorkspace } from '../workspace';
 import { MdWorkspaceInfoCache } from '../workspaceCache';
 import { MdReferenceKind, MdReferencesProvider } from './references';
@@ -201,7 +201,7 @@ export class MdFileRenameProvider {
 
 		// See if the old link was effected by one of the renames
 		for (const edit of allEdits) {
-			if (edit.oldUri.toString() === oldLink.resource.toString() || isParentDir(edit.oldUri, oldLink.resource)) {
+			if (isSameResource(edit.oldUri, oldLink.resource) || isParentDir(edit.oldUri, oldLink.resource)) {
 				oldLink = { resource: Utils.joinPath(edit.newUri, path.posix.relative(edit.oldUri.path, oldLink.resource.path)), linkFragment: oldLink.linkFragment };
 				break;
 			}

--- a/src/languageFeatures/pathCompletions.ts
+++ b/src/languageFeatures/pathCompletions.ts
@@ -17,7 +17,7 @@ import { htmlTagPathAttrs } from '../util/html';
 import * as mdBuilder from '../util/mdBuilder';
 import { escapeForAngleBracketLink, hasBalancedParens } from '../util/mdLinks';
 import { MediaType, getMediaPreviewType } from '../util/media';
-import { computeRelativePath, looksLikeMarkdownFilePath } from '../util/path';
+import { computeRelativePath, isSameResource, looksLikeMarkdownFilePath } from '../util/path';
 import { Schemes } from '../util/schemes';
 import { r } from '../util/string';
 import { FileStat, IWorkspace, getWorkspaceFolder, openLinkToMarkdownFile } from '../workspace';
@@ -416,7 +416,7 @@ export class MdPathCompletionProvider {
 
 		const replacementRange = lsp.Range.create(insertionRange.start, translatePosition(position, { characterDelta: context.linkSuffix.length }));
 		for (const [toDoc, toc] of tocs) {
-			const isHeaderInCurrentDocument = toDoc.toString() === getDocUri(document).toString();
+			const isHeaderInCurrentDocument = isSameResource(toDoc, getDocUri(document));
 
 			const rawPath = isHeaderInCurrentDocument ? '' : computeRelativePath(getDocUri(document), toDoc);
 			if (typeof rawPath === 'undefined') {

--- a/src/languageFeatures/references.ts
+++ b/src/languageFeatures/references.ts
@@ -13,7 +13,7 @@ import { translatePosition } from '../types/position';
 import { areRangesEqual, modifyRange, rangeContains } from '../types/range';
 import { getDocUri, ITextDocument } from '../types/textDocument';
 import { Disposable } from '../util/dispose';
-import { looksLikeMarkdownUri, looksLikePathToResource } from '../util/path';
+import { isSameResource, looksLikeMarkdownUri, looksLikePathToResource } from '../util/path';
 import { IWorkspace, statLinkToMarkdownFile } from '../workspace';
 import { MdWorkspaceInfoCache } from '../workspaceCache';
 
@@ -205,7 +205,7 @@ export class MdReferencesProvider extends Disposable {
 			const references: MdReference[] = [];
 
 			for (const link of allLinksInWorkspace) {
-				if (link.href.kind === HrefKind.External && link.href.uri.toString() === sourceLink.href.uri.toString()) {
+				if (link.href.kind === HrefKind.External && isSameResource(link.href.uri,  sourceLink.href.uri)) {
 					const isTriggerLocation = sourceLink.source.resource.fsPath === link.source.resource.fsPath && areRangesEqual(sourceLink.source.hrefRange, link.source.hrefRange);
 					references.push({
 						kind: MdReferenceKind.Link,

--- a/src/languageFeatures/updatePastedLinks.ts
+++ b/src/languageFeatures/updatePastedLinks.ts
@@ -11,7 +11,7 @@ import { isBefore, isBeforeOrEqual } from '../types/position';
 import { rangeContains } from '../types/range';
 import { getDocUri, ITextDocument } from '../types/textDocument';
 import { removeNewUriExtIfNeeded } from '../util/mdLinks';
-import { computeRelativePath } from '../util/path';
+import { computeRelativePath, isSameResource } from '../util/path';
 import { createAddDefinitionEdit } from './codeActions/extractLinkDef';
 import { MdLinkProvider } from './documentLinks';
 
@@ -70,7 +70,7 @@ export class MdUpdatePastedLinksProvider {
         }
 
         // If pasting into same doc copied from, there's no need to rewrite anything
-        if (getDocUri(targetDocument).toString() === metadata.toString()) {
+        if (isSameResource(getDocUri(targetDocument), metadata.source)) {
             return;
         }
 
@@ -130,7 +130,7 @@ export class MdUpdatePastedLinksProvider {
 
             } else if (link.href.kind === HrefKind.Internal) {
                 const targetDocUri = getDocUri(targetDocument);
-                const newPathText = targetDocUri.toString() === link.href.path.toString()
+                const newPathText = isSameResource(targetDocUri, link.href.path)
                     ? ''
                     : computeRelativePath(targetDocUri, removeNewUriExtIfNeeded(this.#config, link.href, link.href.path));
 

--- a/src/test/updatePastedLinks.test.ts
+++ b/src/test/updatePastedLinks.test.ts
@@ -271,6 +271,22 @@ suite('Update pasted links', () => {
 		));
 	}));
 
+	test('Should noop pasting fragment back to same file', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('doc.md'), joinLines(
+			'# header',
+			''
+		));
+		const workspace = store.add(new InMemoryWorkspace([doc]));
+
+		const resultDocText = await applyUpdateLinksEdits(store,
+			{ copyFrom: doc, pasteTo: doc },
+			[
+				lsp.TextEdit.replace(lsp.Range.create(1, 0, 1, 3), '[a](#header)'),
+			], workspace);
+
+		assert.strictEqual(resultDocText, undefined);
+	}));
+
 	test('Should rewrite fragment link', withStore(async (store) => {
 		const doc = new InMemoryDocument(workspacePath('doc.md'), joinLines(
 			'abcdef',

--- a/src/util/path.ts
+++ b/src/util/path.ts
@@ -9,6 +9,10 @@ import { URI, Utils } from 'vscode-uri';
 import { LsConfiguration } from '../config';
 import { Schemes } from './schemes';
 
+export function isSameResource(a: URI, b: URI): boolean {
+	return a.toString() === b.toString();
+}
+
 export function isParentDir(parent: URI, maybeChild: URI): boolean {
 	if (parent.scheme === maybeChild.scheme && parent.authority === maybeChild.authority) {
 		const relative = path.relative(parent.path, maybeChild.path);


### PR DESCRIPTION
Using `.toString` was unsafe as it hide some typing errors. This PR adds a new `isSameResource` helper which catches these