### PR TITLE
Identify temp versions of documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.5.0-alpha.6 — April 25, 2024
+- Clearly identify temporary versions of documents by setting version to `-1`. This lets clients know not to cache them.
+
 ## 0.5.0-alpha.5 — April 5, 2024
 - Add links to open file in path completions.
 - Add previews for image and video files in path completions.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-markdown-languageservice",
   "description": "Markdown language service",
-  "version": "0.5.0-alpha.5",
+  "version": "0.5.0-alpha.6",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "engines": {

--- a/src/languageFeatures/rename.ts
+++ b/src/languageFeatures/rename.ts
@@ -12,7 +12,7 @@ import { IMdParser } from '../parser';
 import { ISlugifier } from '../slugify';
 import { MdTableOfContentsProvider, TableOfContents, TocEntry } from '../tableOfContents';
 import { HrefKind, InternalHref, MdLink, MdLinkKind, MdLinkSource } from '../types/documentLink';
-import { InMemoryDocument } from '../types/inMemoryDocument';
+import { InMemoryDocument, tempDocVersion } from '../types/inMemoryDocument';
 import { arePositionsEqual, translatePosition } from '../types/position';
 import { modifyRange, rangeContains } from '../types/range';
 import { ITextDocument, getDocUri } from '../types/textDocument';
@@ -227,7 +227,7 @@ export class MdRenameProvider {
 			}
 
 			if (doc) {
-				const editedDoc = new InMemoryDocument(URI.parse(existingHeader.location.uri), doc.getText())
+				const editedDoc = new InMemoryDocument(URI.parse(existingHeader.location.uri), doc.getText(), tempDocVersion)
 					.applyEdits([lsp.TextEdit.replace(existingHeader.location.range, '# ' + newHeaderText)]);
 
 				const [oldToc, newToc] = await Promise.all([

--- a/src/languageFeatures/updatePastedLinks.ts
+++ b/src/languageFeatures/updatePastedLinks.ts
@@ -6,7 +6,7 @@ import * as lsp from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 import { LsConfiguration } from '../config';
 import { HrefKind, LinkDefinitionSet, MdLinkDefinition } from '../types/documentLink';
-import { InMemoryDocument, tempDocVersion as tempDocVersion } from '../types/inMemoryDocument';
+import { InMemoryDocument, tempDocVersion } from '../types/inMemoryDocument';
 import { isBefore, isBeforeOrEqual } from '../types/position';
 import { rangeContains } from '../types/range';
 import { getDocUri, ITextDocument } from '../types/textDocument';

--- a/src/languageFeatures/updatePastedLinks.ts
+++ b/src/languageFeatures/updatePastedLinks.ts
@@ -6,7 +6,7 @@ import * as lsp from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 import { LsConfiguration } from '../config';
 import { HrefKind, LinkDefinitionSet, MdLinkDefinition } from '../types/documentLink';
-import { InMemoryDocument } from '../types/inMemoryDocument';
+import { InMemoryDocument, tempDocVersion as tempDocVersion } from '../types/inMemoryDocument';
 import { isBefore, isBeforeOrEqual } from '../types/position';
 import { rangeContains } from '../types/range';
 import { getDocUri, ITextDocument } from '../types/textDocument';
@@ -83,7 +83,7 @@ export class MdUpdatePastedLinksProvider {
 
         // Find the links in the pasted text by applying the paste edits to an in-memory document.
         // Use `copySource` as the doc uri to make sure links are resolved in its context
-        const editedDoc = new InMemoryDocument(metadata.source, targetDocument.getText());
+        const editedDoc = new InMemoryDocument(metadata.source, targetDocument.getText(), tempDocVersion);
         editedDoc.replaceContents(editedDoc.previewEdits(sortedPastes));
 
         const allLinks = await this.#linkProvider.getLinksWithoutCaching(editedDoc, token);
@@ -206,7 +206,7 @@ export class MdUpdatePastedLinksProvider {
         }
     }
 
-    #computedPastedRanges(sortedPastes: lsp.TextEdit[], targetDocument: ITextDocument, editedDoc: InMemoryDocument) {
+    #computedPastedRanges(sortedPastes: readonly lsp.TextEdit[], targetDocument: ITextDocument, editedDoc: InMemoryDocument): lsp.Range[] {
         const pastedRanges: lsp.Range[] = [];
 
         let offsetAdjustment = 0;


### PR DESCRIPTION
This helps clients that try to cache parsing of md docs