### PR TITLE
#164 Allow common [!ANY] alerts

### DIFF
--- a/src/languageFeatures/documentLinks.ts
+++ b/src/languageFeatures/documentLinks.ts
@@ -171,8 +171,8 @@ const referenceLinkPattern = new RegExp(
 
 	/**/r`|` +
 
-	// [shorthand]
-	/****/r`\[\s*(?<shorthand>(?:\\.|[^\[\]\\])+?)\s*\]` +
+	// [shorthand] but not [!shorthand]
+	/****/r`\[(?!\!)\s*(?<shorthand>(?:\\.|[^\[\]\\])+?)\s*\]` +
 	r`)` +
 	r`(?![\(])`,  // Must not be followed by a paren to avoid matching normal links
 	'gm');
@@ -811,4 +811,3 @@ export function createWorkspaceLinkCache(
 	const linkComputer = new MdLinkComputer(parser, workspace);
 	return new MdWorkspaceInfoCache(workspace, (doc, token) => linkComputer.getAllLinks(doc, token));
 }
-

--- a/src/test/documentLinks.test.ts
+++ b/src/test/documentLinks.test.ts
@@ -255,6 +255,14 @@ suite('Link computer', () => {
 		]);
 	});
 
+	test('Should not find reference link shorthand when prefixed with ! (#164)', async () => {
+		const links = await getLinksForText(joinLines(
+			'[!note]',
+			'[!anything]',
+		));
+		assertLinksEqual(links, []);
+	});
+
 	test('Should find reference link with space in reference name', async () => {
 		const links = await getLinksForText(joinLines(
 			'[text][my ref]',


### PR DESCRIPTION
Allow [common alert syntax](https://learn.microsoft.com/en-us/contribute/content/markdown-reference#alerts-note-tip-important-caution-warning) used in Microsoft Learn and on [GitHub](https://github.com/orgs/community/discussions/16925) without raising `link.no-such-reference`. Fixing #164 

