### PR TITLE
Update @vscode/l10n to version 0.0.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.5.0-alpha.8",
       "license": "MIT",
       "dependencies": {
-        "@vscode/l10n": "^0.0.10",
+        "@vscode/l10n": "^0.0.18",
         "node-html-parser": "^6.1.5",
         "picomatch": "^2.3.1",
         "vscode-languageserver-protocol": "^3.17.1",
@@ -700,9 +700,10 @@
       "dev": true
     },
     "node_modules/@vscode/l10n": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.10.tgz",
-      "integrity": "sha512-E1OCmDcDWa0Ya7vtSjp/XfHFGqYJfh+YPC1RkATU71fTac+j1JjCcB3qwSzmlKAighx2WxhLlfhS0RwAN++PFQ=="
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+      "license": "MIT"
     },
     "node_modules/acorn": {
       "version": "8.11.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "types/vscode-markdown-languageservice.d.ts"
   ],
   "dependencies": {
-    "@vscode/l10n": "^0.0.10",
+    "@vscode/l10n": "^0.0.18",
     "node-html-parser": "^6.1.5",
     "picomatch": "^2.3.1",
     "vscode-languageserver-protocol": "^3.17.1",


### PR DESCRIPTION
This gets rid of the punycode deprecation warning.