### PR TITLE
Strip hashes from markdown headers

### DIFF
--- a/src/languageFeatures/documentSymbols.ts
+++ b/src/languageFeatures/documentSymbols.ts
@@ -94,11 +94,11 @@ export class MdDocumentSymbolProvider {
 			while (additionalSymbols.length && isBefore(additionalSymbols[0].range.end, entry.sectionLocation.range.start)) {
 				parent.children.push(additionalSymbols.shift()!);
 			}
-	
+
 			while (parent && entry.level <= parent.level) {
 				parent = parent.parent;
 			}
-			
+
 			if (!parent) {
 				// Should not happen
 				return;
@@ -107,21 +107,17 @@ export class MdDocumentSymbolProvider {
 			const symbol = this.#tocToDocumentSymbol(entry);
 			symbol.children = [];
 			parent.children.push(symbol);
-			
+
 			parent = { level: entry.level, children: symbol.children, parent, range: entry.sectionLocation.range };
 		}
 	}
 
 	#tocToDocumentSymbol(entry: TocEntry): lsp.DocumentSymbol {
 		return {
-			name: this.#getTocSymbolName(entry),
+			name: entry.text,
 			kind: lsp.SymbolKind.String,
 			range: entry.sectionLocation.range,
 			selectionRange: entry.sectionLocation.range
 		};
-	}
-
-	#getTocSymbolName(entry: TocEntry): string {
-		return '#'.repeat(entry.level) + ' ' + entry.text;
 	}
 }

--- a/src/test/documentSymbols.test.ts
+++ b/src/test/documentSymbols.test.ts
@@ -87,14 +87,14 @@ suite('Document symbols', () => {
 	test('Should return single symbol for single header', withStore(async (store) => {
 		const symbols = await getSymbolsForFile(store, '# h');
 		assertDocumentSymbolsEqual(symbols, [
-			{ name: '# h' },
+			{ name: 'h' },
 		]);
 	}));
 
 	test('Should not care about symbol level for single header', withStore(async (store) => {
 		const symbols = await getSymbolsForFile(store, '### h');
 		assertDocumentSymbolsEqual(symbols, [
-			{ name: '### h' },
+			{ name: 'h' },
 		]);
 	}));
 
@@ -104,8 +104,8 @@ suite('Document symbols', () => {
 			`## h2`,
 		));
 		assertDocumentSymbolsEqual(symbols, [
-			{ name: '## h' },
-			{ name: '## h2' },
+			{ name: 'h' },
+			{ name: 'h2' },
 		]);
 	}));
 
@@ -117,10 +117,10 @@ suite('Document symbols', () => {
 		));
 		assertDocumentSymbolsEqual(symbols, [
 			{
-				name: '# h',
+				name: 'h',
 				children: [
-					{ name: '## h2' },
-					{ name: '## h3' },
+					{ name: 'h2' },
+					{ name: 'h3' },
 				]
 			}
 		]);
@@ -133,9 +133,9 @@ suite('Document symbols', () => {
 		));
 		assertDocumentSymbolsEqual(symbols, [
 			{
-				name: '# h',
+				name: 'h',
 				children: [
-					{ name: '#### h2' }
+					{ name: 'h2' }
 				]
 			}
 		]);
@@ -149,10 +149,10 @@ suite('Document symbols', () => {
 		));
 		assertDocumentSymbolsEqual(symbols, [
 			{
-				name: '# h',
+				name: 'h',
 				children: [
-					{ name: '### h2' },
-					{ name: '## h3' },
+					{ name: 'h2' },
+					{ name: 'h3' },
 				]
 			},
 		]);
@@ -167,8 +167,8 @@ suite('Document symbols', () => {
 			`- bar`,
 		));
 		assertDocumentSymbolsEqual(symbols, [
-			{ name: '# A' },
-			{ name: '# B' },
+			{ name: 'A' },
+			{ name: 'B' },
 		]);
 	}));
 
@@ -207,16 +207,16 @@ suite('Document symbols', () => {
 		assertDocumentSymbolsEqual(symbols, [
 			{ name: '[def 1]', range: lsp.Range.create(0, 0, 0, 27), selectionRange: lsp.Range.create(0, 1, 0, 6), },
 			{
-				name: '# h1',
+				name: 'h1',
 				children: [
 					{ name: '[def 2]', range: lsp.Range.create(2, 0, 2, 27), selectionRange: lsp.Range.create(2, 1, 2, 6), },
 					{
-						name: '#### h2',
+						name: 'h2',
 						children: [
 							{ name: '[def 3]', range: lsp.Range.create(4, 0, 4, 27), selectionRange: lsp.Range.create(4, 1, 4, 6), },
 						]
 					},
-					{ name: '## h3', children: [] },
+					{ name: 'h3', children: [] },
 				]
 			},
 			{ name: '[def 4]', range: lsp.Range.create(6, 0, 6, 27), selectionRange: lsp.Range.create(6, 1, 6, 6), },
@@ -229,8 +229,8 @@ suite('Document symbols', () => {
 			'## [a `b` **c**](http://example.com)',
 		));
 		assertDocumentSymbolsEqual(symbols, [
-			{ name: '## a b c' },
-			{ name: '## a b c' },
+			{ name: 'a b c' },
+			{ name: 'a b c' },
 		]);
 	}));
 
@@ -239,7 +239,7 @@ suite('Document symbols', () => {
 			'## <b>a</b> `b` **c**',
 		));
 		assertDocumentSymbolsEqual(symbols, [
-			{ name: '## a b c' },
+			{ name: 'a b c' },
 		]);
 	}));
 });

--- a/src/test/workspaceSymbol.test.ts
+++ b/src/test/workspaceSymbol.test.ts
@@ -44,7 +44,7 @@ suite('Workspace symbols', () => {
 			new InMemoryDocument(workspacePath('test.md'), `# header1\nabc\n## header2`)
 		]));
 
-		assertSymbolsMatch(await getWorkspaceSymbols(store, workspace, ''), ['# header1', '## header2']);
+		assertSymbolsMatch(await getWorkspaceSymbols(store, workspace, ''), ['header1', 'header2']);
 	}));
 
 	test('Should return all content basic workspace', withStore(async (store) => {
@@ -71,7 +71,7 @@ suite('Workspace symbols', () => {
 
 		// Update file
 		workspace.updateDocument(new InMemoryDocument(testFileName, `# new header\nabc\n## header2`, 2 /* version */));
-		assertSymbolsMatch(await getWorkspaceSymbols(store, workspace, ''), ['# new header', '## header2']);
+		assertSymbolsMatch(await getWorkspaceSymbols(store, workspace, ''), ['new header', 'header2']);
 	}));
 
 	test('Should remove results when file is deleted', withStore(async (store) => {
@@ -112,7 +112,7 @@ suite('Workspace symbols', () => {
 			))
 		]));
 
-		assertSymbolsMatch(await getWorkspaceSymbols(store, workspace, ''), ['# header1']);
+		assertSymbolsMatch(await getWorkspaceSymbols(store, workspace, ''), ['header1']);
 	}));
 
 	test('Should match case insensitively', withStore(async (store) => {
@@ -120,8 +120,8 @@ suite('Workspace symbols', () => {
 			new InMemoryDocument(workspacePath('test.md'), `# aBc1\nabc\n## ABc2`)
 		]));
 
-		assertSymbolsMatch(await getWorkspaceSymbols(store, workspace, 'ABC'), ['# aBc1', '## ABc2']);
-		assertSymbolsMatch(await getWorkspaceSymbols(store, workspace, 'abc'), ['# aBc1', '## ABc2']);
+		assertSymbolsMatch(await getWorkspaceSymbols(store, workspace, 'ABC'), ['aBc1', 'ABc2']);
+		assertSymbolsMatch(await getWorkspaceSymbols(store, workspace, 'abc'), ['aBc1', 'ABc2']);
 	}));
 
 	test('Should match fuzzyily', withStore(async (store) => {
@@ -129,11 +129,11 @@ suite('Workspace symbols', () => {
 			new InMemoryDocument(workspacePath('test.md'), `# cat dog fish`)
 		]));
 
-		assertSymbolsMatch(await getWorkspaceSymbols(store, workspace, 'cat'), ['# cat dog fish']);
-		assertSymbolsMatch(await getWorkspaceSymbols(store, workspace, 'cdf'), ['# cat dog fish']);
-		assertSymbolsMatch(await getWorkspaceSymbols(store, workspace, 'catfish'), ['# cat dog fish']);
+		assertSymbolsMatch(await getWorkspaceSymbols(store, workspace, 'cat'), ['cat dog fish']);
+		assertSymbolsMatch(await getWorkspaceSymbols(store, workspace, 'cdf'), ['cat dog fish']);
+		assertSymbolsMatch(await getWorkspaceSymbols(store, workspace, 'catfish'), ['cat dog fish']);
 		assertSymbolsMatch(await getWorkspaceSymbols(store, workspace, 'fishcat'), []); // wrong order
-		assertSymbolsMatch(await getWorkspaceSymbols(store, workspace, 'ccat'), []); 
+		assertSymbolsMatch(await getWorkspaceSymbols(store, workspace, 'ccat'), []);
 	}));
 
 	test('Should strip markup in headers', withStore(async (store) => {
@@ -144,6 +144,6 @@ suite('Workspace symbols', () => {
 			))
 		]));
 
-		assertSymbolsMatch(await getWorkspaceSymbols(store, workspace, 'a'), ['# a b c', '# a x y']);
+		assertSymbolsMatch(await getWorkspaceSymbols(store, workspace, 'a'), ['a b c', 'a x y']);
 	}));
 });


### PR DESCRIPTION
It seems more reasonable to strip the hashes and use the inherent nature of the symbol's children to determine the associated levels for each header. This will tie into a PR in VS Code, in addition to https://github.com/microsoft/vscode-codicons/pull/442, which adds icons to further distinguish between header levels.

This is how I fetched the level heading in an extension I was designing using Lua. It's *very* possible and, imo, more practical since hashes are markdown-specific anyway:

```lua
---@param symbols LuaSymbol[]
---@return StructureNode[]
function GetDocumentStructure(symbols, level)
    local structure = {}
    if not level then
        level = 1
    end
    for i = 1, #symbols do
        local symbol = symbols[i]
        local line = 0
        if symbol.selectionRange and symbol.selectionRange.start then
            line = symbol.selectionRange.start.line
        elseif symbol.range and symbol.range.start then
            line = symbol.range.start.line
        end
        local name = symbol.name:gsub("#", ""):gsub("^%s+", ""):gsub("%s+$", "")
        local node = MakeNode(name, "h" .. level, line)
        if (symbol.children) then
            node.children = GetDocumentStructure(symbol.children, level + 1)
        end
        table.insert(structure, node)
    end
    return structure
end

```