### PR TITLE
Prep for supporting html ids in toc

### DIFF
--- a/src/languageFeatures/definitions.ts
+++ b/src/languageFeatures/definitions.ts
@@ -36,9 +36,9 @@ export class MdDefinitionProvider {
 			return [];
 		}
 
-		const header = toc.entries.find(entry => entry.line === position.line);
-		if (header) {
-			return header.headerLocation;
+		const entryAtPosition = toc.entries.find(entry => rangeContains(entry.declarationLocation.range, position));
+		if (entryAtPosition) {
+			return entryAtPosition.declarationLocation;
 		}
 
 		return this.#getDefinitionOfLinkAtPosition(document, position, token);
@@ -74,7 +74,7 @@ export class MdDefinitionProvider {
 		}
 
 		const toc = await this.#tocProvider.get(resolvedResource);
-		return toc?.lookupByFragment(sourceLink.href.fragment)?.headerLocation;
+		return toc?.lookupByFragment(sourceLink.href.fragment)?.declarationLocation;
 	}
 
 	#getDefinitionOfRef(ref: string, allLinksInFile: readonly MdLink[]) {

--- a/src/languageFeatures/documentHighlights.ts
+++ b/src/languageFeatures/documentHighlights.ts
@@ -43,7 +43,7 @@ export class MdDocumentHighlightProvider {
 			return [];
 		}
 
-		const header = toc.entries.find(entry => entry.line === position.line);
+		const header = toc.entries.find(entry => rangeContains(entry.declarationLocation.range, position));
 		if (header) {
 			return [...this.#getHighlightsForHeader(document, header, links, toc)];
 		}
@@ -52,7 +52,7 @@ export class MdDocumentHighlightProvider {
 	}
 
 	*#getHighlightsForHeader(document: ITextDocument, header: TocEntry, links: readonly MdLink[], toc: TableOfContents): Iterable<lsp.DocumentHighlight> {
-		yield { range: header.headerLocation.range, kind: lsp.DocumentHighlightKind.Write };
+		yield { range: header.declarationLocation.range, kind: lsp.DocumentHighlightKind.Write };
 
 		const docUri = getDocUri(document);
 		for (const link of links) {
@@ -108,7 +108,7 @@ export class MdDocumentHighlightProvider {
 		if (isSameResource(targetDoc, getDocUri(document))) {
 			const header = toc.lookupByFragment(fragment);
 			if (header) {
-				yield { range: header.headerLocation.range, kind: lsp.DocumentHighlightKind.Write };
+				yield { range: header.declarationLocation.range, kind: lsp.DocumentHighlightKind.Write };
 			}
 		}
 

--- a/src/languageFeatures/documentLinks.ts
+++ b/src/languageFeatures/documentLinks.ts
@@ -756,7 +756,12 @@ export class MdLinkProvider extends Disposable {
 			const toc = await this.#tocProvider.getForContainingDoc(doc, token);
 			const entry = toc.lookByLink({ fragment: linkData.fragment, isAngleBracketLink: linkData.isAngleBracketLink });
 			if (entry) {
-				return { kind: 'file', uri: URI.parse(entry.headerLocation.uri), positionOrRange: entry.headerLocation.range.start, fragment: linkData.fragment };
+				return {
+					kind: 'file',
+					uri: URI.parse(entry.declarationLocation.uri),
+					positionOrRange: entry.declarationLocation.range.start,
+					fragment: linkData.fragment
+				};
 			}
 		}
 

--- a/src/languageFeatures/documentSymbols.ts
+++ b/src/languageFeatures/documentSymbols.ts
@@ -5,7 +5,7 @@
 
 import * as lsp from 'vscode-languageserver-protocol';
 import { ILogger, LogLevel } from '../logging';
-import { MdTableOfContentsProvider, TableOfContents, TocEntry } from '../tableOfContents';
+import { MdTableOfContentsProvider, TableOfContents, TocEntry, TocHeaderEntry } from '../tableOfContents';
 import { MdLinkDefinition, MdLinkKind } from '../types/documentLink';
 import { isBefore } from '../types/position';
 import { ITextDocument } from '../types/textDocument';
@@ -91,14 +91,18 @@ export class MdDocumentSymbolProvider {
 	#buildTocSymbolTree(root: MarkdownSymbol, entries: readonly TocEntry[], additionalSymbols: lsp.DocumentSymbol[]): void {
 		let parent: MarkdownSymbol | undefined = root;
 		for (const entry of entries) {
+			if (entry.kind !== 'header') {
+				continue;
+			}
+
 			while (additionalSymbols.length && isBefore(additionalSymbols[0].range.end, entry.sectionLocation.range.start)) {
 				parent.children.push(additionalSymbols.shift()!);
 			}
-	
+
 			while (parent && entry.level <= parent.level) {
 				parent = parent.parent;
 			}
-			
+
 			if (!parent) {
 				// Should not happen
 				return;
@@ -107,12 +111,12 @@ export class MdDocumentSymbolProvider {
 			const symbol = this.#tocToDocumentSymbol(entry);
 			symbol.children = [];
 			parent.children.push(symbol);
-			
+
 			parent = { level: entry.level, children: symbol.children, parent, range: entry.sectionLocation.range };
 		}
 	}
 
-	#tocToDocumentSymbol(entry: TocEntry): lsp.DocumentSymbol {
+	#tocToDocumentSymbol(entry: TocHeaderEntry): lsp.DocumentSymbol {
 		return {
 			name: this.#getTocSymbolName(entry),
 			kind: lsp.SymbolKind.String,
@@ -121,7 +125,7 @@ export class MdDocumentSymbolProvider {
 		};
 	}
 
-	#getTocSymbolName(entry: TocEntry): string {
+	#getTocSymbolName(entry: TocHeaderEntry): string {
 		return '#'.repeat(entry.level) + ' ' + entry.text;
 	}
 }

--- a/src/languageFeatures/folding.ts
+++ b/src/languageFeatures/folding.ts
@@ -6,7 +6,7 @@
 import * as lsp from 'vscode-languageserver-protocol';
 import { ILogger, LogLevel } from '../logging';
 import { IMdParser, Token, TokenWithMap } from '../parser';
-import { MdTableOfContentsProvider } from '../tableOfContents';
+import { MdTableOfContentsProvider, TocHeaderEntry } from '../tableOfContents';
 import { getLine, ITextDocument } from '../types/textDocument';
 import { isEmptyOrWhitespace } from '../util/string';
 
@@ -76,13 +76,15 @@ export class MdFoldingProvider {
 			return [];
 		}
 
-		return toc.entries.map((entry): lsp.FoldingRange => {
-			let endLine = entry.sectionLocation.range.end.line;
-			if (isEmptyOrWhitespace(getLine(document, endLine)) && endLine >= entry.line + 1) {
-				endLine = endLine - 1;
-			}
-			return { startLine: entry.line, endLine };
-		});
+		return toc.entries
+			.filter((entry): entry is TocHeaderEntry => entry.kind === 'header')
+			.map((entry): lsp.FoldingRange => {
+				let endLine = entry.sectionLocation.range.end.line;
+				if (isEmptyOrWhitespace(getLine(document, endLine)) && endLine >= entry.declarationLocation.range.start.line + 1) {
+					endLine = endLine - 1;
+				}
+				return { startLine: entry.declarationLocation.range.start.line, endLine };
+			});
 	}
 
 	async #getBlockFoldingRanges(document: ITextDocument, token: lsp.CancellationToken): Promise<lsp.FoldingRange[]> {

--- a/src/languageFeatures/pathCompletions.ts
+++ b/src/languageFeatures/pathCompletions.ts
@@ -10,7 +10,7 @@ import * as lsp from 'vscode-languageserver-protocol';
 import { URI, Utils } from 'vscode-uri';
 import { LsConfiguration, isExcludedPath } from '../config';
 import { IMdParser } from '../parser';
-import { MdTableOfContentsProvider, TableOfContents, TocEntry } from '../tableOfContents';
+import { MdTableOfContentsProvider, TableOfContents, TocHeaderEntry } from '../tableOfContents';
 import { translatePosition } from '../types/position';
 import { ITextDocument, getDocUri, getLine } from '../types/textDocument';
 import { htmlTagPathAttrs } from '../util/html';
@@ -108,14 +108,14 @@ export enum IncludeWorkspaceHeaderCompletions {
 
 	/**
 	 * Return workspace header completions after `##` is typed.
-	 * 
-	 * This lets the user signal 
+	 *
+	 * This lets the user signal
 	 */
 	onDoubleHash = 'onDoubleHash',
 
 	/**
 	 * Return workspace header completions after either a single `#` is typed or after `##`
-	 * 
+	 *
 	 * For a single hash, this means the workspace header completions will be returned along side the current file header completions.
 	 */
 	onSingleOrDoubleHash = 'onSingleOrDoubleHash',
@@ -128,7 +128,7 @@ export interface PathCompletionOptions {
 	/**
 	 * Should header completions for other files in the workspace be returned when
 	 * you trigger completions.
-	 * 
+	 *
 	 * Defaults to {@link IncludeWorkspaceHeaderCompletions.never never} (not returned).
 	 */
 	readonly includeWorkspaceHeaderCompletions?: IncludeWorkspaceHeaderCompletions;
@@ -393,15 +393,17 @@ export class MdPathCompletionProvider {
 
 		const replacementRange = lsp.Range.create(insertionRange.start, translatePosition(position, { characterDelta: context.linkSuffix.length }));
 		for (const entry of toc.entries) {
-			const completionItem = this.#createHeaderCompletion(entry, insertionRange, replacementRange);
-			completionItem.labelDetails = {
+			if (entry.kind !== 'header') {
+				continue;
+			}
 
-			};
+			const completionItem = this.#createHeaderCompletion(entry, insertionRange, replacementRange);
+			completionItem.labelDetails = {};
 			yield completionItem;
 		}
 	}
 
-	#createHeaderCompletion(entry: TocEntry, insertionRange: lsp.Range, replacementRange: lsp.Range, filePath = ''): lsp.CompletionItem {
+	#createHeaderCompletion(entry: TocHeaderEntry, insertionRange: lsp.Range, replacementRange: lsp.Range, filePath = ''): lsp.CompletionItem {
 		const label = '#' + decodeURIComponent(entry.slug.value);
 		const newText = filePath + '#' + decodeURIComponent(entry.slug.value);
 		return {
@@ -416,7 +418,7 @@ export class MdPathCompletionProvider {
 		};
 	}
 
-	#ownHeaderEntryDetails(entry: TocEntry): string | undefined {
+	#ownHeaderEntryDetails(entry: TocHeaderEntry): string | undefined {
 		return l10n.t(`Link to '{0}'`, '#'.repeat(entry.level) + ' ' + entry.text);
 	}
 
@@ -441,6 +443,10 @@ export class MdPathCompletionProvider {
 			const normalizedPath = this.#normalizeFileNameCompletion(rawPath);
 			const path = this.#getPathInsertText(context, normalizedPath);
 			for (const entry of toc.entries) {
+				if (entry.kind !== 'header') {
+					continue;
+				}
+
 				const completionItem = this.#createHeaderCompletion(entry, insertionRange, replacementRange, path);
 				completionItem.filterText = '#' + completionItem.label;
 				completionItem.sortText = isHeaderInCurrentDocument ? sortTexts.localHeader : sortTexts.workspaceHeader;

--- a/src/languageFeatures/references.ts
+++ b/src/languageFeatures/references.ts
@@ -7,7 +7,7 @@ import { URI } from 'vscode-uri';
 import { LsConfiguration } from '../config';
 import { ILogger, LogLevel } from '../logging';
 import { IMdParser } from '../parser';
-import { MdTableOfContentsProvider, TocEntry } from '../tableOfContents';
+import { MdTableOfContentsProvider, TocHeaderEntry } from '../tableOfContents';
 import { HrefKind, MdLink, MdLinkKind } from '../types/documentLink';
 import { translatePosition } from '../types/position';
 import { areRangesEqual, modifyRange, rangeContains } from '../types/range';
@@ -42,27 +42,9 @@ export interface MdHeaderReference {
 
 	readonly isTriggerLocation: boolean;
 	readonly isDefinition: boolean;
-
-	/**
-	 * The range of the header.
-	 *
-	 * In `# a b c #` this would be the range of `# a b c #`
-	 */
 	readonly location: lsp.Location;
 
-	/**
-	 * The text of the header.
-	 *
-	 * In `# a b c #` this would be `a b c`
-	 */
-	readonly headerText: string;
-
-	/**
-	 * The range of the header text itself.
-	 *
-	 * In `# a b c #` this would be the range of `a b c`
-	 */
-	readonly headerTextLocation: lsp.Location;
+	readonly header: TocHeaderEntry;
 }
 
 export type MdReference = MdLinkReference | MdHeaderReference;
@@ -112,9 +94,13 @@ export class MdReferencesProvider extends Disposable {
 			return [];
 		}
 
-		const header = toc.entries.find(entry => entry.line === position.line);
+		const header = toc.entries.find(entry => rangeContains(entry.declarationLocation.range, position));
 		if (header) {
-			return this.#getReferencesToHeader(document, header, token);
+			if (header.kind === 'header') {
+				return this.#getReferencesToHeader(document, header, token);
+			} else {
+				return [];
+			}
 		} else {
 			return this.#getReferencesToLinkAtPosition(document, position, token);
 		}
@@ -131,7 +117,7 @@ export class MdReferencesProvider extends Disposable {
 		return Array.from(this.#findLinksToFile(resource, allLinksInWorkspace, undefined));
 	}
 
-	async #getReferencesToHeader(document: ITextDocument, header: TocEntry, token: lsp.CancellationToken): Promise<MdReference[]> {
+	async #getReferencesToHeader(document: ITextDocument, header: TocHeaderEntry, token: lsp.CancellationToken): Promise<MdReference[]> {
 		const links = await this.#getAllLinksInWorkspace();
 		if (token.isCancellationRequested) {
 			return [];
@@ -143,9 +129,8 @@ export class MdReferencesProvider extends Disposable {
 			kind: MdReferenceKind.Header,
 			isTriggerLocation: true,
 			isDefinition: true,
-			location: header.headerLocation,
-			headerText: header.text,
-			headerTextLocation: header.headerTextLocation
+			location: header.declarationLocation,
+			header,
 		});
 
 		for (const link of links) {
@@ -205,7 +190,7 @@ export class MdReferencesProvider extends Disposable {
 			const references: MdReference[] = [];
 
 			for (const link of allLinksInWorkspace) {
-				if (link.href.kind === HrefKind.External && isSameResource(link.href.uri,  sourceLink.href.uri)) {
+				if (link.href.kind === HrefKind.External && isSameResource(link.href.uri, sourceLink.href.uri)) {
 					const isTriggerLocation = sourceLink.source.resource.fsPath === link.source.resource.fsPath && areRangesEqual(sourceLink.source.hrefRange, link.source.hrefRange);
 					references.push({
 						kind: MdReferenceKind.Link,
@@ -229,14 +214,13 @@ export class MdReferencesProvider extends Disposable {
 		if (resolvedResource && this.#isMarkdownPath(resolvedResource) && sourceLink.href.fragment && sourceLink.source.hrefFragmentRange && rangeContains(sourceLink.source.hrefFragmentRange, triggerPosition)) {
 			const toc = await this.#tocProvider.get(resolvedResource);
 			const entry = toc?.lookupByFragment(sourceLink.href.fragment);
-			if (entry) {
+			if (entry && entry.kind === 'header') {
 				references.push({
 					kind: MdReferenceKind.Header,
 					isTriggerLocation: false,
 					isDefinition: true,
-					location: entry.headerLocation,
-					headerText: entry.text,
-					headerTextLocation: entry.headerTextLocation
+					location: entry.declarationLocation,
+					header: entry,
 				});
 			}
 

--- a/src/languageFeatures/rename.ts
+++ b/src/languageFeatures/rename.ts
@@ -88,7 +88,7 @@ export class MdRenameProvider {
 		const triggerRef = allRefsInfo.triggerRef;
 		switch (triggerRef.kind) {
 			case MdReferenceKind.Header: {
-				return { range: triggerRef.headerTextLocation.range, placeholder: triggerRef.headerText };
+				return { range: triggerRef.header.idDeclarationLocation.range, placeholder: triggerRef.header.text };
 			}
 			case MdReferenceKind.Link: {
 				if (triggerRef.link.kind === MdLinkKind.Definition) {
@@ -108,7 +108,7 @@ export class MdRenameProvider {
 					const declaration = this.#findHeaderDeclaration(allRefsInfo.references);
 					return {
 						range: hrefFragmentRange,
-						placeholder: declaration ? declaration.headerText : document.getText(hrefFragmentRange),
+						placeholder: declaration ? declaration.header.text : document.getText(hrefFragmentRange),
 					};
 				}
 
@@ -207,7 +207,7 @@ export class MdRenameProvider {
 			// There are two cases of this to consider:
 			//
 			// - The new name duplicates an existing header. In this case, we need to use the unique slug of the new header
-			// but also potentially update links to the other duplicated headers. 
+			// but also potentially update links to the other duplicated headers.
 			//
 			// - The old header was duplicated. This may result in links to other instances of the duplicated headers changing
 			//
@@ -245,7 +245,7 @@ export class MdRenameProvider {
 						return;
 					}
 
-					if (oldEntry.headerLocation.range.start.line === existingHeader.location.range.start.line) {
+					if (oldEntry.declarationLocation.range.start.line === existingHeader.location.range.start.line) {
 						newSlug = newEntry.slug; // Take the new slug from the edited document
 						return;
 					}
@@ -256,7 +256,7 @@ export class MdRenameProvider {
 				});
 
 				for (const changedHeader of changedHeaders) {
-					const refs = await this.#getAllReferences(doc, changedHeader.headerLocation.range.start, token);
+					const refs = await this.#getAllReferences(doc, changedHeader.declarationLocation.range.start, token);
 					if (token.isCancellationRequested) {
 						return;
 					}
@@ -273,7 +273,7 @@ export class MdRenameProvider {
 		for (const ref of allRefsInfo.references) {
 			switch (ref.kind) {
 				case MdReferenceKind.Header:
-					builder.replace(URI.parse(ref.location.uri), ref.headerTextLocation.range, newHeaderText);
+					builder.replace(URI.parse(ref.location.uri), ref.header.idDeclarationLocation.range, newHeaderText);
 					break;
 
 				case MdReferenceKind.Link:

--- a/src/languageFeatures/smartSelect.ts
+++ b/src/languageFeatures/smartSelect.ts
@@ -5,7 +5,7 @@
 import * as lsp from 'vscode-languageserver-protocol';
 import { ILogger, LogLevel } from '../logging';
 import { IMdParser, Token, TokenWithMap } from '../parser';
-import { MdTableOfContentsProvider, TocEntry } from '../tableOfContents';
+import { MdTableOfContentsProvider, TocEntry, TocHeaderEntry } from '../tableOfContents';
 import { translatePosition } from '../types/position';
 import { areRangesEqual, modifyRange, rangeContains } from '../types/range';
 import { getLine, ITextDocument } from '../types/textDocument';
@@ -83,28 +83,31 @@ export class MdSelectionRangeProvider {
 			return undefined;
 		}
 
-		const headerInfo = getHeadersForPosition(toc.entries, position);
+		const headerInfo = getHeadersForPosition(toc.entries.filter((entry): entry is TocHeaderEntry => entry.kind === 'header'), position);
 		const headers = headerInfo.headers;
 
 		let currentRange: lsp.SelectionRange | undefined;
 		for (let i = 0; i < headers.length; i++) {
-			currentRange = createHeaderRange(headers[i], i === headers.length - 1, headerInfo.headerOnThisLine, currentRange, getFirstChildHeader(document, headers[i], toc.entries));
+			const tocEntry = headers[i];
+			if (tocEntry.kind === 'header') {
+				currentRange = createHeaderRange(tocEntry, i === headers.length - 1, headerInfo.headerOnThisLine, currentRange, getFirstChildHeader(document, tocEntry, toc.entries));
+			}
 		}
 		return currentRange;
 	}
 }
 
-function getHeadersForPosition(toc: readonly TocEntry[], position: lsp.Position): { headers: TocEntry[]; headerOnThisLine: boolean } {
+function getHeadersForPosition(toc: readonly TocHeaderEntry[], position: lsp.Position): { headers: TocEntry[]; headerOnThisLine: boolean } {
 	const enclosingHeaders = toc.filter(header => header.sectionLocation.range.start.line <= position.line && header.sectionLocation.range.end.line >= position.line);
-	const sortedHeaders = enclosingHeaders.sort((header1, header2) => (header1.line - position.line) - (header2.line - position.line));
-	const onThisLine = toc.find(header => header.line === position.line) !== undefined;
+	const sortedHeaders = enclosingHeaders.sort((header1, header2) => (header1.declarationLocation.range.start.line - position.line) - (header2.declarationLocation.range.start.line - position.line));
+	const onThisLine = toc.find(header => header.declarationLocation.range.start.line === position.line) !== undefined;
 	return {
 		headers: sortedHeaders,
 		headerOnThisLine: onThisLine
 	};
 }
 
-function createHeaderRange(header: TocEntry, isClosestHeaderToPosition: boolean, onHeaderLine: boolean, parent?: lsp.SelectionRange, startOfChildRange?: lsp.Position): lsp.SelectionRange | undefined {
+function createHeaderRange(header: TocHeaderEntry, isClosestHeaderToPosition: boolean, onHeaderLine: boolean, parent?: lsp.SelectionRange, startOfChildRange?: lsp.Position): lsp.SelectionRange | undefined {
 	const range = header.sectionLocation.range;
 	const contentRange = lsp.Range.create(translatePosition(range.start, { lineDelta: 1 }), range.end);
 	if (onHeaderLine && isClosestHeaderToPosition && startOfChildRange) {
@@ -414,10 +417,10 @@ function isBlockElement(token: Token): boolean {
 	return !['list_item_close', 'paragraph_close', 'bullet_list_close', 'inline', 'heading_close', 'heading_open'].includes(token.type);
 }
 
-function getFirstChildHeader(document: ITextDocument, header?: TocEntry, toc?: readonly TocEntry[]): lsp.Position | undefined {
+function getFirstChildHeader(document: ITextDocument, header?: TocHeaderEntry, toc?: readonly TocEntry[]): lsp.Position | undefined {
 	let childRange: lsp.Position | undefined;
 	if (header && toc) {
-		const children = toc.filter(t => rangeContains(header.sectionLocation.range, t.sectionLocation.range) && t.sectionLocation.range.start.line > header.sectionLocation.range.start.line).sort((t1, t2) => t1.line - t2.line);
+		const children = toc.filter((t): t is TocHeaderEntry => t.kind === 'header' && rangeContains(header.sectionLocation.range, t.sectionLocation.range) && t.sectionLocation.range.start.line > header.sectionLocation.range.start.line).sort((t1, t2) => t1.declarationLocation.range.start.line - t2.declarationLocation.range.start.line);
 		if (children.length > 0) {
 			childRange = children[0].sectionLocation.range.start;
 			const lineText = getLine(document, childRange.line - 1);

--- a/src/tableOfContents.ts
+++ b/src/tableOfContents.ts
@@ -13,7 +13,11 @@ import { Disposable } from './util/dispose';
 import { IWorkspace } from './workspace';
 import { MdDocumentInfoCache } from './workspaceCache';
 
-export interface TocEntry {
+export type TocEntry = TocHeaderEntry;
+
+export interface TocHeaderEntry {
+	readonly kind: 'header';
+
 	readonly slug: ISlug;
 
 	/**
@@ -22,7 +26,34 @@ export interface TocEntry {
 	readonly text: string;
 
 	readonly level: number;
-	readonly line: number;
+
+	/**
+	 * The range of the header declaration.
+	 *
+	 * For the doc:
+	 *
+	 * ```md
+	 * # Head #
+	 * text
+	 * ```
+	 *
+	 * This is the range of `# Head #`
+	 */
+	readonly declarationLocation: lsp.Location;
+
+	/**
+	 * The range of the header text.
+	 *
+	 * For the doc:
+	 *
+	 * ```md
+	 * # Head #
+	 * text
+	 * ```
+	 *
+	 * This is the range of `Head`
+	 */
+	readonly idDeclarationLocation: lsp.Location;
 
 	/**
 	 * The entire range of the header section.
@@ -38,34 +69,6 @@ export interface TocEntry {
 	 * This is the range from `# Head #` to `# Next head #`
 	 */
 	readonly sectionLocation: lsp.Location;
-
-	/**
-	 * The range of the header declaration.
-	 *
-	 * For the doc:
-	 *
-	 * ```md
-	 * # Head #
-	 * text
-	 * ```
-	 *
-	 * This is the range of `# Head #`
-	 */
-	readonly headerLocation: lsp.Location;
-
-	/**
-	 * The range of the header text.
-	 *
-	 * For the doc:
-	 *
-	 * ```md
-	 * # Head #
-	 * text
-	 * ```
-	 *
-	 * This is the range of `Head`
-	 */
-	readonly headerTextLocation: lsp.Location;
 }
 
 export class TableOfContents {
@@ -146,22 +149,27 @@ export class TableOfContents {
 			};
 
 			toc.push({
+				kind: 'header',
 				slug,
 				text: bodyText.trim(),
 				level: TableOfContents.#getHeaderLevel(open.markup),
-				line: lineNumber,
 				sectionLocation: headerLocation, // Populated in next steps
-				headerLocation,
-				headerTextLocation
+				declarationLocation: headerLocation,
+				idDeclarationLocation: headerTextLocation
 			});
 		}
 
 		// Get full range of section
 		return toc.map((entry, startIndex): TocEntry => {
+			if (entry.kind !== 'header') {
+				return entry;
+			};
+
 			let end: number | undefined = undefined;
 			for (let i = startIndex + 1; i < toc.length; ++i) {
-				if (toc[i].level <= entry.level) {
-					end = toc[i].line - 1;
+				const targetToc = toc[i];
+				if (targetToc.kind === 'header' && targetToc.level <= entry.level) {
+					end = targetToc.declarationLocation.range.start.line - 1;
 					break;
 				}
 			}

--- a/src/test/references.test.ts
+++ b/src/test/references.test.ts
@@ -712,10 +712,10 @@ suite('References', () => {
 				];
 
 				// Trigger h1
-				assertReferencesEqual(await getReferences(store, doc, { line: 0, character: 10 }, workspace), ...firstHeaderLocations);
+				assertReferencesEqual(await getReferences(store, doc, { line: 0, character: 4 }, workspace), ...firstHeaderLocations);
 
 				// Trigger doc link to h1
-				assertReferencesEqual(await getReferences(store, doc, { line: 2, character: 10 }, workspace), ...firstHeaderLocations);
+				assertReferencesEqual(await getReferences(store, doc, { line: 2, character: 8 }, workspace), ...firstHeaderLocations);
 
 				// Trigger other link to h1
 				assertReferencesEqual(await getReferences(store, otherDoc, { line: 0, character: 12 }, workspace), ...firstHeaderLocations);
@@ -728,7 +728,7 @@ suite('References', () => {
 				];
 
 				// Trigger h2
-				assertReferencesEqual(await getReferences(store, doc, { line: 1, character: 10 }, workspace), ...secondHeaderLocations);
+				assertReferencesEqual(await getReferences(store, doc, { line: 1, character: 4 }, workspace), ...secondHeaderLocations);
 
 				// Trigger doc link to h2
 				assertReferencesEqual(await getReferences(store, doc, { line: 3, character: 10 }, workspace), ...secondHeaderLocations);

--- a/src/test/tableOfContents.test.ts
+++ b/src/test/tableOfContents.test.ts
@@ -53,7 +53,7 @@ suite('Table of contents', () => {
 		{
 			const entry = provider.lookupByFragment('a');
 			assert.ok(entry);
-			assert.strictEqual(entry!.line, 0);
+			assert.strictEqual(entry!.declarationLocation.range.start.line, 0);
 		}
 		{
 			assert.strictEqual(provider.lookupByFragment('x'), undefined);
@@ -61,7 +61,7 @@ suite('Table of contents', () => {
 		{
 			const entry = provider.lookupByFragment('c');
 			assert.ok(entry);
-			assert.strictEqual(entry!.line, 2);
+			assert.strictEqual(entry!.declarationLocation.range.start.line, 2);
 		}
 	});
 
@@ -72,9 +72,9 @@ suite('Table of contents', () => {
 		));
 		const provider = await createToc(doc);
 
-		assert.strictEqual((provider.lookupByFragment('fOo'))!.line, 0);
-		assert.strictEqual((provider.lookupByFragment('foo'))!.line, 0);
-		assert.strictEqual((provider.lookupByFragment('FOO'))!.line, 0);
+		assert.strictEqual((provider.lookupByFragment('fOo'))!.declarationLocation.range.start.line, 0);
+		assert.strictEqual((provider.lookupByFragment('foo'))!.declarationLocation.range.start.line, 0);
+		assert.strictEqual((provider.lookupByFragment('FOO'))!.declarationLocation.range.start.line, 0);
 	});
 
 	test('should handle special characters #44779', async () => {
@@ -84,7 +84,7 @@ suite('Table of contents', () => {
 		));
 		const provider = await createToc(doc);
 
-		assert.strictEqual((provider.lookupByFragment('indentação'))!.line, 0);
+		assert.strictEqual((provider.lookupByFragment('indentação'))!.declarationLocation.range.start.line, 0);
 	});
 
 	test('should handle special characters 2, #48482', async () => {
@@ -94,7 +94,7 @@ suite('Table of contents', () => {
 		));
 		const provider = await createToc(doc);
 
-		assert.strictEqual((provider.lookupByFragment('инструкция---делай-раз-делай-два'))!.line, 0);
+		assert.strictEqual((provider.lookupByFragment('инструкция---делай-раз-делай-два'))!.declarationLocation.range.start.line, 0);
 	});
 
 	test('should handle special characters 3, #37079', async () => {
@@ -109,12 +109,12 @@ suite('Table of contents', () => {
 
 		const provider = await createToc(doc);
 
-		assert.strictEqual((provider.lookupByFragment('header-2'))!.line, 0);
-		assert.strictEqual((provider.lookupByFragment('header-3'))!.line, 1);
-		assert.strictEqual((provider.lookupByFragment('Заголовок-2'))!.line, 2);
-		assert.strictEqual((provider.lookupByFragment('Заголовок-3'))!.line, 3);
-		assert.strictEqual((provider.lookupByFragment('Заголовок-header-3'))!.line, 4);
-		assert.strictEqual((provider.lookupByFragment('Заголовок'))!.line, 5);
+		assert.strictEqual((provider.lookupByFragment('header-2'))!.declarationLocation.range.start.line, 0);
+		assert.strictEqual((provider.lookupByFragment('header-3'))!.declarationLocation.range.start.line, 1);
+		assert.strictEqual((provider.lookupByFragment('Заголовок-2'))!.declarationLocation.range.start.line, 2);
+		assert.strictEqual((provider.lookupByFragment('Заголовок-3'))!.declarationLocation.range.start.line, 3);
+		assert.strictEqual((provider.lookupByFragment('Заголовок-header-3'))!.declarationLocation.range.start.line, 4);
+		assert.strictEqual((provider.lookupByFragment('Заголовок'))!.declarationLocation.range.start.line, 5);
 	});
 
 	test('Lookup should support suffixes for repeated headers', async () => {
@@ -128,17 +128,17 @@ suite('Table of contents', () => {
 		{
 			const entry = provider.lookupByFragment('a');
 			assert.ok(entry);
-			assert.strictEqual(entry!.line, 0);
+			assert.strictEqual(entry!.declarationLocation.range.start.line, 0);
 		}
 		{
 			const entry = provider.lookupByFragment('a-1');
 			assert.ok(entry);
-			assert.strictEqual(entry!.line, 1);
+			assert.strictEqual(entry!.declarationLocation.range.start.line, 1);
 		}
 		{
 			const entry = provider.lookupByFragment('a-2');
 			assert.ok(entry);
-			assert.strictEqual(entry!.line, 2);
+			assert.strictEqual(entry!.declarationLocation.range.start.line, 2);
 		}
 	});
 


### PR DESCRIPTION
- Makes `TocEntry` more abstract instead of being specific to headers
- Remove and rename fields from header doc
- Reuse header entry for `MdHeaderReference`