### PR TITLE
Preserve encoded external markdown links

### DIFF
--- a/src/languageFeatures/documentLinks.ts
+++ b/src/languageFeatures/documentLinks.ts
@@ -20,7 +20,6 @@ import { resolveInternalDocumentLink } from '../util/mdLinks.js';
 import { NoLinkRanges } from '../util/noLinkRanges.js';
 import { parseLocationInfoFromFragment } from '../util/path.js';
 import { r } from '../util/string.js';
-import { tryDecodeUri } from '../util/uri.js';
 import { URI } from '../util/vscodeUri.js';
 import { IWorkspace, tryAppendMarkdownFileExtension } from '../workspace.js';
 import { MdDocumentInfoCache, MdWorkspaceInfoCache } from '../workspaceCache.js';
@@ -35,7 +34,7 @@ function createHref(
 	if (/^[a-z\-][a-z\-]+:/i.test(link)) {
 		// Looks like a uri
 		try {
-			return { kind: HrefKind.External, uri: URI.parse(tryDecodeUri(link)) };
+			return { kind: HrefKind.External, uri: URI.parse(link) };
 		} catch (e) {
 			console.warn(r`Failed to parse link ${link} in ${sourceDocUri.toString(true)}`);
 			return undefined;
@@ -717,7 +716,7 @@ export class MdLinkProvider extends Disposable {
 			case HrefKind.External: {
 				return {
 					range: link.source.hrefRange,
-					target: link.href.uri.toString(true),
+					target: link.source.hrefText,
 				};
 			}
 			case HrefKind.Internal: {

--- a/src/test/documentLinks.test.ts
+++ b/src/test/documentLinks.test.ts
@@ -943,6 +943,22 @@ suite('Link provider', () => {
 		assert.strictEqual(links[0].target, exampleUrl);
 	});
 
+	test('Should preserve encoded reserved characters in external links (#245128)', async () => {
+		const exampleUrl = 'https://ffmpeg.org/ffmpeg-all.html?test=a%23b%20c#:~:text=%2Dversion';
+		const links = await getLinksForFile(joinLines(
+			`[link](${exampleUrl})`
+		));
+		assert.strictEqual(links[0].target, exampleUrl);
+	});
+
+	test('Should preserve encoded slashes in external links (#245128)', async () => {
+		const exampleUrl = 'https://firebasestorage.googleapis.com/v0/b/project/o/folder%2Ffile.png?alt=media&token=abc%2Fdef';
+		const links = await getLinksForFile(joinLines(
+			`[link](${exampleUrl})`
+		));
+		assert.strictEqual(links[0].target, exampleUrl);
+	});
+
 	test('Should resolve href fragment links in angle brackets', async () => {
 		const doc = new InMemoryDocument(testFile, joinLines(
 			`# a b c`,


### PR DESCRIPTION
Fixes microsoft/vscode#245128.

## Summary
- Preserve the original Markdown href text for external DocumentLink targets instead of reserializing through URI.toString(true).
- Avoid decoding external URL text before parsing it for link metadata.
- Add regression coverage for encoded reserved characters such as `%23`, `%2D`, and `%2F`.

## Why
Encoded reserved characters are semantically significant in external URLs. For example, Firebase Storage URLs can use `%2F` inside object names and token values. The current behavior opens `folder%2Ffile.png` as `folder/file.png`, which can point to a different resource.

## Testing
- `git diff --check`
- Added regression tests in `src/test/documentLinks.test.ts`
- Not run locally: `npm ci` fails in this local workspace with `ENOSPC` while creating `node_modules/.bin`; CI should run the full test suite.