### PR TITLE
Preserve encoded markdown link targets

### DIFF
--- a/src/languageFeatures/documentLinks.ts
+++ b/src/languageFeatures/documentLinks.ts
@@ -20,7 +20,6 @@ import { resolveInternalDocumentLink } from '../util/mdLinks.js';
 import { NoLinkRanges } from '../util/noLinkRanges.js';
 import { parseLocationInfoFromFragment } from '../util/path.js';
 import { r } from '../util/string.js';
-import { tryDecodeUri } from '../util/uri.js';
 import { URI } from '../util/vscodeUri.js';
 import { IWorkspace, tryAppendMarkdownFileExtension } from '../workspace.js';
 import { MdDocumentInfoCache, MdWorkspaceInfoCache } from '../workspaceCache.js';
@@ -35,7 +34,7 @@ function createHref(
 	if (/^[a-z\-][a-z\-]+:/i.test(link)) {
 		// Looks like a uri
 		try {
-			return { kind: HrefKind.External, uri: URI.parse(tryDecodeUri(link)) };
+			return { kind: HrefKind.External, uri: URI.parse(link), rawTarget: link };
 		} catch (e) {
 			console.warn(r`Failed to parse link ${link} in ${sourceDocUri.toString(true)}`);
 			return undefined;
@@ -717,7 +716,7 @@ export class MdLinkProvider extends Disposable {
 			case HrefKind.External: {
 				return {
 					range: link.source.hrefRange,
-					target: link.href.uri.toString(true),
+					target: link.href.rawTarget,
 				};
 			}
 			case HrefKind.Internal: {

--- a/src/test/documentLinks.test.ts
+++ b/src/test/documentLinks.test.ts
@@ -943,6 +943,18 @@ suite('Link provider', () => {
 		assert.strictEqual(links[0].target, exampleUrl);
 	});
 
+	test('Should preserve encoded external link targets', async () => {
+		const encodedPathUrl = 'https://firebasestorage.googleapis.com/v0/b/brewlangerie.appspot.com/o/products%2FzVNZkudXJyq8bPGTXUxx%2FBetterave-Sesame.jpg?alt=media&token=0b2310c4-3ea6-4207-bbde-9c3710ba0437';
+		const textFragmentUrl = 'https://ffmpeg.org/ffmpeg-all.html?test=a%23b%20c#:~:text=%2Dversion';
+		const links = await getLinksForFile(joinLines(
+			`[encoded-path](${encodedPathUrl})`,
+			`[text-fragment](${textFragmentUrl})`,
+		));
+
+		assert.strictEqual(links[0].target, encodedPathUrl);
+		assert.strictEqual(links[1].target, textFragmentUrl);
+	});
+
 	test('Should resolve href fragment links in angle brackets', async () => {
 		const doc = new InMemoryDocument(testFile, joinLines(
 			`# a b c`,

--- a/src/types/documentLink.ts
+++ b/src/types/documentLink.ts
@@ -14,6 +14,7 @@ export enum HrefKind {
 export interface ExternalHref {
 	readonly kind: HrefKind.External;
 	readonly uri: URI;
+	readonly rawTarget: string;
 }
 
 export interface InternalHref {


### PR DESCRIPTION
## Summary
- Preserve the original external markdown link text for `DocumentLink.target` instead of serializing it through `vscode-uri`.
- Keep the parsed URI for existing comparison/highlight behavior.
- Add regression coverage for encoded path/query/text-fragment URLs from microsoft/vscode#245128.

## Validation
- `PATH="/Users/William/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm run compile`
- `PATH="/Users/William/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm test`
- `PATH="/Users/William/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm run lint`
- `PATH="/Users/William/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm run api-extractor`

Related to microsoft/vscode#245128.