### PR TITLE
Ignore markdown links inside HTML comments

### DIFF
--- a/src/test/documentLinks.test.ts
+++ b/src/test/documentLinks.test.ts
@@ -459,8 +459,8 @@ suite('Link computer', () => {
 		assertLinksEqual(links, []);
 	});
 
-	test.skip('Should not detect links inside inline html comments', async () => {
-		// See #149678
+	test('Should not detect links inside inline html comments', async () => {
+		// See microsoft/vscode-markdown-languageservice#52
 		const links = await getLinksForText(joinLines(
 			`text <!-- <http://example.com> --> text`,
 			`text <!-- [text](./foo.md) --> text`,

--- a/src/util/noLinkRanges.ts
+++ b/src/util/noLinkRanges.ts
@@ -9,6 +9,7 @@ import { rangeContains } from '../types/range.js';
 import { ITextDocument } from '../types/textDocument.js';
 
 const inlineCodePattern = /(?<!`)(`+)((?:.+?|.*?(?:(?:\r?\n).+?)*?)(?:\r?\n)?\1)(?!`)/gm;
+const htmlCommentPattern = /<!--[\s\S]*?-->/g;
 
 class InlineRanges {
 
@@ -56,6 +57,11 @@ export class NoLinkRanges {
 		const inlineRanges = InlineRanges.create();
 		const text = document.getText();
 		for (const match of text.matchAll(inlineCodePattern)) {
+			const startOffset = match.index ?? 0;
+			const startPosition = document.positionAt(startOffset);
+			inlineRanges.add(lsp.Range.create(startPosition, document.positionAt(startOffset + match[0].length)));
+		}
+		for (const match of text.matchAll(htmlCommentPattern)) {
 			const startOffset = match.index ?? 0;
 			const startPosition = document.positionAt(startOffset);
 			inlineRanges.add(lsp.Range.create(startPosition, document.positionAt(startOffset + match[0].length)));


### PR DESCRIPTION
## Summary
- Treat HTML comment spans as no-link ranges when computing markdown links.
- Enable the existing skipped regression test for inline HTML comments.

## Validation
- `PATH="/Users/William/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm run compile`
- `PATH="/Users/William/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm test`
- `PATH="/Users/William/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm run lint`

Fixes #52.