### PR TITLE
Show reference link definitions on hover

### DIFF
--- a/src/languageFeatures/hover.ts
+++ b/src/languageFeatures/hover.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as lsp from 'vscode-languageserver-protocol';
-import { HrefKind, MdLink } from '../types/documentLink.js';
+import { HrefKind, MdLink, MdLinkDefinition } from '../types/documentLink.js';
 import { rangeContains } from '../types/range.js';
 import { ITextDocument } from '../types/textDocument.js';
 import * as mdBuilder from '../util/mdBuilder.js';
@@ -20,17 +20,19 @@ export class MdHoverProvider {
 	}
 
 	public async provideHover(document: ITextDocument, pos: lsp.Position, token: lsp.CancellationToken): Promise<lsp.Hover | undefined> {
-		const links = await this.#linkProvider.getLinks(document);
+		const linksInfo = await this.#linkProvider.getLinks(document);
 		if (token.isCancellationRequested) {
 			return;
 		}
 
-		const link = links.links.find(link => rangeContains(link.source.hrefRange, pos));
-		if (!link || link.href.kind === HrefKind.Reference) {
+		const link = linksInfo.links.find(link => rangeContains(link.source.hrefRange, pos));
+		if (!link) {
 			return;
 		}
 
-		const contents = this.#getHoverContents(link);
+		const contents = link.href.kind === HrefKind.Reference
+			? this.#getReferenceLinkHover(document, linksInfo.definitions.lookup(link.href.ref))
+			: this.#getHoverContents(link);
 		return contents && {
 			contents,
 			range: link.source.hrefRange
@@ -61,4 +63,21 @@ export class MdHoverProvider {
 		}
 		return undefined;
 	}
+
+	#getReferenceLinkHover(document: ITextDocument, definition: MdLinkDefinition | undefined): lsp.MarkupContent | undefined {
+		if (!definition) {
+			return undefined;
+		}
+
+		return {
+			kind: 'markdown',
+			value: codeBlock('markdown', document.getText(definition.source.range)),
+		};
+	}
+}
+
+function codeBlock(language: string, contents: string): string {
+	const longestBacktickSequence = Math.max(0, ...Array.from(contents.matchAll(/`+/g), ([match]) => match.length));
+	const backticks = '`'.repeat(Math.max(3, longestBacktickSequence + 1));
+	return `${backticks}${language}\n${contents}\n${backticks}`;
 }

--- a/src/test/hover.test.ts
+++ b/src/test/hover.test.ts
@@ -73,6 +73,22 @@ suite('Hover', () => {
 		assert.ok(!await getHover(store, doc, { line: 0, character: 19 }, workspace));
 	}));
 
+	test('Should show reference link definition on hover', withStore(async (store) => {
+		const doc = new InMemoryDocument(workspacePath('doc.md'), joinLines(
+			`[example][ref]`,
+			``,
+			`[ref]: https://example.com "Example"`,
+		));
+		const workspace = store.add(new InMemoryWorkspace([doc]));
+
+		const hover = await getHover(store, doc, { line: 0, character: 11 }, workspace);
+		assert.ok(hover);
+		assert.ok(lsp.MarkupContent.is(hover.contents));
+		assert.strictEqual(hover.contents.value, '```markdown\n[ref]: https://example.com "Example"\n```');
+
+		assertRangeEqual(lsp.Range.create(0, 10, 0, 13), hover.range!);
+	}));
+
 	test('Should return image hover on MD image path', withStore(async (store) => {
 		const doc = new InMemoryDocument(workspacePath('doc.md'), joinLines(
 			`![img](./cat.png)`,


### PR DESCRIPTION
## Summary
- Show the current link definition when hovering over a defined reference link.
- Keep existing document link navigation intact while avoiding a context switch for quick checks.
- Add hover coverage for reference link definitions.

## Validation
- `PATH="/Users/William/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm run compile`
- `PATH="/Users/William/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm test`
- `PATH="/Users/William/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm run lint`

Fixes #74.